### PR TITLE
Lab 4: trace, outside-in debug, and TLS handshake decode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Thumbs.db
 #   *.sbom.cdx.json, zap-*.html/json, trivy-*.txt   (Lab 9 scan evidence)
 #   flake.nix, flake.lock      (Lab 11)
 #   wasm/main.go, spin.toml, go.sum   (Lab 12)
+
+# Lab 4 packet capture (binary, regenerable)
+submissions/*.pcap

--- a/submissions/lab4-capture.sh
+++ b/submissions/lab4-capture.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Lab 4 Task 1 — capture + decode one POST /notes, then run the 5 debug commands.
+# Run from WSL:  bash submissions/lab4-capture.sh
+# It will prompt for your sudo password once (tcpdump needs root).
+set -uo pipefail
+
+# WSL's system Go is 1.22; QuickNotes' go.mod needs >= 1.24. Use the user-local
+# Go 1.24 we unpacked into ~/go124 and pin GOTOOLCHAIN so it won't try to fetch.
+export PATH="$HOME/go124/go/bin:$PATH"
+export GOTOOLCHAIN=local
+
+REPO="/mnt/c/study/DEVOPS/DevOps-Intro"
+APP="$REPO/app"
+OUT="$REPO/submissions"
+WORK="$(mktemp -d)"
+PCAP="$WORK/lab4-trace.pcap"
+
+echo "[*] Warm up sudo (tcpdump needs root)..."
+sudo -v
+
+echo "[*] Starting QuickNotes on :8080 ..."
+cd "$APP"
+ADDR=:8080 go run . >"$WORK/qn.log" 2>&1 &
+QN_PID=$!
+for i in $(seq 1 40); do
+  ss -tln 2>/dev/null | grep -q ':8080' && break
+  sleep 0.3
+done
+echo "    listening: $(ss -tln | grep ':8080' || echo 'NOT UP — see qn.log'); pid=$QN_PID"
+
+echo "[*] Starting tcpdump on lo ..."
+sudo tcpdump -i lo -nn -s 0 -A 'tcp port 8080' -w "$PCAP" >/dev/null 2>&1 &
+TCPDUMP_PID=$!
+sleep 1.5
+
+echo "[*] Firing one POST /notes (verbose -> lab4-curl.txt) ..."
+curl -v -X POST http://localhost:8080/notes \
+  -H 'Content-Type: application/json' \
+  -d '{"title":"trace me","body":"in flight"}' 2>"$OUT/lab4-curl.txt"
+echo
+sleep 1.5
+
+echo "[*] Stopping capture ..."
+sudo kill "$TCPDUMP_PID" 2>/dev/null
+wait "$TCPDUMP_PID" 2>/dev/null
+
+echo "[*] Decoding capture -> lab4-trace.txt ..."
+sudo tcpdump -r "$PCAP" -nn -A 2>/dev/null | tee "$OUT/lab4-trace.txt" >/dev/null
+cp "$PCAP" "$OUT/lab4-trace.pcap" 2>/dev/null
+sudo chown "$(id -un)":"$(id -gn)" "$OUT/lab4-trace.txt" "$OUT/lab4-trace.pcap" 2>/dev/null
+
+echo "[*] Running the five debug commands -> lab4-commands.txt ..."
+{
+  echo "### 1. ss -tlnp | grep :8080  (what's listening?)"
+  sudo ss -tlnp | grep ':8080' || echo "(nothing on :8080)"
+  echo; echo "### 2. ip route show  (routes from this host)"
+  ip route show
+  echo; echo "### 3. mtr -rwc 5 localhost  (reachability over lo)"
+  sudo mtr -rwc 5 localhost || echo "(mtr unavailable)"
+  echo; echo "### 4. dig +short example.com @1.1.1.1  (DNS works?)"
+  dig +short example.com @1.1.1.1 || echo "(dig unavailable)"
+  echo; echo "### 5. journalctl --user -u quicknotes -n 20  (service logs)"
+  journalctl --user -u quicknotes -n 20 2>/dev/null \
+    || echo "(QuickNotes is not installed as a systemd unit here — it runs via 'go run', so there is no journald unit; logs went to stdout)"
+} | tee "$OUT/lab4-commands.txt"
+
+echo "[*] Cleaning up ..."
+kill "$QN_PID" 2>/dev/null
+pkill -f '/quicknotes' 2>/dev/null
+pkill -f 'go run' 2>/dev/null
+rm -rf "$WORK"
+
+echo "[+] Done. Artifacts written to $OUT:"
+ls -la "$OUT"/lab4-trace.txt "$OUT"/lab4-curl.txt "$OUT"/lab4-commands.txt "$OUT"/lab4-trace.pcap 2>/dev/null

--- a/submissions/lab4-commands.txt
+++ b/submissions/lab4-commands.txt
@@ -1,0 +1,18 @@
+### 1. ss -tlnp | grep :8080  (what's listening?)
+LISTEN 0      4096                *:8080            *:*    users:(("quicknotes",pid=1300,fd=3))     
+
+### 2. ip route show  (routes from this host)
+default via 172.28.16.1 dev eth0 proto kernel 
+172.28.16.0/20 dev eth0 proto kernel scope link src 172.28.27.7 
+
+### 3. mtr -rwc 5 localhost  (reachability over lo)
+Start: 2026-06-16T20:56:27+0300
+HOST: rikire    Loss%   Snt   Last   Avg  Best  Wrst StDev
+  1.|-- localhost  0.0%     5    0.0   0.0   0.0   0.0   0.0
+
+### 4. dig +short example.com @1.1.1.1  (DNS works?)
+172.66.147.243
+104.20.23.154
+
+### 5. journalctl --user -u quicknotes -n 20  (service logs)
+-- No entries --

--- a/submissions/lab4-curl.txt
+++ b/submissions/lab4-curl.txt
@@ -1,0 +1,19 @@
+Note: Unnecessary use of -X or --request, POST is already inferred.
+* Host localhost:8080 was resolved.
+* IPv6: ::1
+* IPv4: 127.0.0.1
+*   Trying [::1]:8080...
+* Connected to localhost (::1) port 8080
+> POST /notes HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/8.5.0
+> Accept: */*
+> Content-Type: application/json
+> Content-Length: 39
+> 
+< HTTP/1.1 201 Created
+< Content-Type: application/json
+< Date: Tue, 16 Jun 2026 17:56:25 GMT
+< Content-Length: 92
+< 
+* Connection #0 to host localhost left intact

--- a/submissions/lab4-debug.sh
+++ b/submissions/lab4-debug.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Lab 4 Task 2 — reproduce a broken deploy (port already in use) and walk the
+# outside-in debugging chain, then repair and re-verify.
+# Run from WSL:  bash submissions/lab4-debug.sh   (writes /tmp/lab4-task2.txt)
+set -uo pipefail
+export PATH="$HOME/go124/go/bin:/usr/sbin:/usr/bin:/bin:$PATH"
+export GOTOOLCHAIN=local
+
+APP="/mnt/c/study/DEVOPS/DevOps-Intro/app"
+OUT="/mnt/c/study/DEVOPS/DevOps-Intro/submissions/lab4-task2.txt"
+cd "$APP"
+pkill -f /quicknotes 2>/dev/null; sleep 1
+
+# all report output -> file (so background jobs never hold the caller's pipe)
+exec >"$OUT" 2>&1
+
+echo "=== 2.1  Start instance #1 (takes :8080) ==="
+ADDR=:8080 nohup go run . >/tmp/qn1.log 2>&1 </dev/null &
+P1=$!; disown
+for i in $(seq 1 80); do ss -tln 2>/dev/null | grep -q :8080 && break; sleep 0.3; done
+echo "instance #1: go-pid=$P1, listeners on :8080 = $(ss -tln | grep -c :8080)"
+
+echo
+echo "=== 2.1  Start instance #2 on the SAME port (must fail) ==="
+ADDR=:8080 go run . >/tmp/qn2.log 2>&1 </dev/null
+echo "instance #2 exit code = $?"
+echo "--- exact error ---"
+cat /tmp/qn2.log
+
+echo
+echo "=== 2.2  OUTSIDE-IN CHAIN ==="
+echo "### 1) is it running?   ps -ef | grep quicknotes"
+ps -ef | grep -E "quicknotes|go run \." | grep -v grep
+echo
+echo "### 2) is it listening?  ss -tlnp | grep 8080"
+ss -tlnp 2>/dev/null | grep 8080
+echo
+echo "### 3) reachable from host?  curl /health"
+curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8080/health
+echo
+echo "### 4) firewall blocking?  iptables/nft  (needs sudo; run separately if empty here)"
+{ sudo -n iptables -L -n -v 2>/dev/null || sudo -n nft list ruleset 2>/dev/null; } \
+  || echo "(could not read firewall non-interactively — see note in submission)"
+echo
+echo "### 5) DNS?  dig +short localhost  (+ /etc/hosts)"
+dig +short localhost 2>/dev/null
+echo "/etc/hosts: $(grep -w localhost /etc/hosts | tr '\n' ' ')"
+
+echo
+echo "=== 2.3  REPAIR: kill the conflicting #1, restart, re-verify ==="
+kill "$P1" 2>/dev/null
+pkill -f /quicknotes 2>/dev/null
+sleep 2
+ADDR=:8080 nohup go run . >/tmp/qn3.log 2>&1 </dev/null &
+disown
+for i in $(seq 1 80); do ss -tln 2>/dev/null | grep -q :8080 && break; sleep 0.3; done
+echo "after repair, /health = $(curl -s http://localhost:8080/health)"
+pkill -f /quicknotes 2>/dev/null
+echo
+echo "=== DONE ==="

--- a/submissions/lab4-task2.txt
+++ b/submissions/lab4-task2.txt
@@ -1,0 +1,32 @@
+=== 2.1  Start instance #1 (takes :8080) ===
+instance #1: go-pid=1795, listeners on :8080 = 1
+
+=== 2.1  Start instance #2 on the SAME port (must fail) ===
+instance #2 exit code = 1
+--- exact error ---
+2026/06/16 21:04:17 quicknotes listening on :8080 (notes loaded: 8)
+2026/06/16 21:04:17 listen: listen tcp :8080: bind: address already in use
+exit status 1
+
+=== 2.2  OUTSIDE-IN CHAIN ===
+### 1) is it running?   ps -ef | grep quicknotes
+aboba       1795    1792 45 21:04 pts/2    00:00:00 go run .
+aboba       1898    1795  0 21:04 pts/2    00:00:00 /home/aboba/.cache/go-build/7d/7d215502e255ad20200a610375c249a2b4a323ed30f0ae6eeba8fafdc3dc3c39-d/quicknotes
+
+### 2) is it listening?  ss -tlnp | grep 8080
+LISTEN 0      4096                *:8080            *:*    users:(("quicknotes",pid=1898,fd=3))
+
+### 3) reachable from host?  curl /health
+HTTP 200
+
+### 4) firewall blocking?  iptables/nft  (needs sudo; run separately if empty here)
+(could not read firewall non-interactively — see note in submission)
+
+### 5) DNS?  dig +short localhost  (+ /etc/hosts)
+127.0.0.1
+/etc/hosts: 127.0.0.1	localhost ::1     ip6-localhost ip6-loopback 
+
+=== 2.3  REPAIR: kill the conflicting #1, restart, re-verify ===
+after repair, /health = {"notes":8,"status":"ok"}
+
+=== DONE ===

--- a/submissions/lab4-tls-capture.txt
+++ b/submissions/lab4-tls-capture.txt
@@ -1,0 +1,24 @@
+=== start QuickNotes (:8080) and TLS proxy (:8443) ===
+listeners: 8080=1  8443=1
+proxy.log: 2026/06/16 21:11:05 TLS proxy listening on :8443 -> http://127.0.0.1:8080
+
+=== capture handshake on lo:8443 ===
+--- curl -vk https://localhost:8443/health (verbose -> lab4-tls-curl.txt) ---
+{"notes":8,"status":"ok"}
+
+=== certificate chain (openssl s_client -showcerts) ===
+subject=CN = localhost
+issuer=CN = localhost
+notBefore=Jun 16 18:11:03 2026 GMT
+notAfter=Jun 17 18:11:03 2026 GMT
+
+=== negotiated session (openssl s_client summary) ===
+Verification error: self-signed certificate
+New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
+Server public key is 2048 bit
+Verify return code: 18 (self-signed certificate)
+    Protocol  : TLSv1.3
+    Cipher    : TLS_AES_128_GCM_SHA256
+    Verify return code: 18 (self-signed certificate)
+
+=== DONE. pcap: -rwxrwxrwx 1 aboba aboba 4786 Jun 16 21:11 /mnt/c/study/DEVOPS/DevOps-Intro/submissions/lab4-tls.pcap ===

--- a/submissions/lab4-tls-cert.txt
+++ b/submissions/lab4-tls-cert.txt
@@ -1,0 +1,76 @@
+CONNECTED(00000003)
+---
+Certificate chain
+ 0 s:CN = localhost
+   i:CN = localhost
+   a:PKEY: rsaEncryption, 2048 (bit); sigalg: RSA-SHA256
+   v:NotBefore: Jun 16 18:11:03 2026 GMT; NotAfter: Jun 17 18:11:03 2026 GMT
+-----BEGIN CERTIFICATE-----
+MIIDHzCCAgegAwIBAgIUS4rpbB1N7bDyNnlg1B1h91HTpEgwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDYxNjE4MTEwM1oXDTI2MDYx
+NzE4MTEwM1owFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAx24uSTPnmS1EM7kDWLBPoJxArRsAlIMKXX8R2/VslYhe
+Ya98uTtP9ipShX2df8bfbi+5PtUyVayylyk3wr3IhKFEa0dtTMJAz7BmfEV+ccna
+zpOuBQ0IMjAUEpAG11HINHAktyxwU9lRzyjXssb47Zk4LySeBCoQ4Duqp9EW3eae
+i88ppFiPNq+BTMDp+nAN3S2KptA4sNc/gHmsHN4zwUM8jIurUpvow6xQO/NO7zdf
+DUMM6Dzu9MWV39wrPlWJVctaykafTzJUIzv8vJH8gLYilMZ9O8o620i9FKcxR3Y/
+hZ514Ao+P5iRmG44l0h1HxC4lWAlJE/hHW0z6Xe48wIDAQABo2kwZzAdBgNVHQ4E
+FgQUfyLTwxg3e/SRHrho745lHIMsYmgwHwYDVR0jBBgwFoAUfyLTwxg3e/SRHrho
+745lHIMsYmgwDwYDVR0TAQH/BAUwAwEB/zAUBgNVHREEDTALgglsb2NhbGhvc3Qw
+DQYJKoZIhvcNAQELBQADggEBAIPr/03Frol/HJ1ECw3oCkMmeBnNulsracNtlfvL
+2Rwgzp9NNLkgaKr/4dVkEf12AlmTUohONE4plKAQ80nYIu6l/11FyIV0wNUus3kr
+Fk/UyxgT9cKDm/RMyxgbqAM5ZtRBQ9i0Ac9NQSVWYgvd4nDQYBLoyukpy5TIXfkf
+6iaoDMQWD8p4ciEedM80rPxbgTztqUxJ7X8yGPc01tkbrDWMQCL4mMO/nPGZH/FT
+NEusZ2DhLvKaP3p1vpXXs9anv5l7Nul9+tGkp1IyJ0VP/bTm569hUHSTpQ/ZnfMd
+ntsx4MY7mBtMNnElAI+ZCQHLC0chJpQvwqQ5Q9XtlLTz/PI=
+-----END CERTIFICATE-----
+---
+Server certificate
+subject=CN = localhost
+issuer=CN = localhost
+---
+No client certificate CA names sent
+Peer signing digest: SHA256
+Peer signature type: RSA-PSS
+Server Temp Key: X25519, 253 bits
+---
+SSL handshake has read 1343 bytes and written 357 bytes
+Verification error: self-signed certificate
+---
+New, TLSv1.3, Cipher is TLS_AES_128_GCM_SHA256
+Server public key is 2048 bit
+Secure Renegotiation IS NOT supported
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+Early data was not sent
+Verify return code: 18 (self-signed certificate)
+---
+---
+Post-Handshake New Session Ticket arrived:
+SSL-Session:
+    Protocol  : TLSv1.3
+    Cipher    : TLS_AES_128_GCM_SHA256
+    Session-ID: C12B26BD8DC51839E441BC2865C06CFC910ACCF9A82030C2C65D9E677F174711
+    Session-ID-ctx: 
+    Resumption PSK: 78DD29BD0302C828D99365F2C1BB37BE0AEECB7155ADEAA6158B486D0DBDD6FF
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    TLS session ticket lifetime hint: 604800 (seconds)
+    TLS session ticket:
+    0000 - 2e bd e6 7a bb 4b a9 f4-1f 1c 46 d3 e8 57 70 00   ...z.K....F..Wp.
+    0010 - 62 30 3d bd 55 c7 22 09-d0 4e d4 f3 47 12 bf 88   b0=.U."..N..G...
+    0020 - 0e 7b a1 f8 9d 81 2e b2-7e cd 9f 38 5d ab 1a 36   .{......~..8]..6
+    0030 - af 66 5f b3 32 1e 16 6b-b5 80 d6 e7 f6 5b 16 de   .f_.2..k.....[..
+    0040 - 30 1d 7d 5b 15 46 0c 8a-80 f2 14 92 45 5b ed 0a   0.}[.F......E[..
+    0050 - 04 a4 69 bf 75 82 88 ac-ee 72 35 69 a7 53 d3 0e   ..i.u....r5i.S..
+    0060 - cb b8 5b b1 f5 fe 5d b4-f4                        ..[...]..
+
+    Start Time: 1781633468
+    Timeout   : 7200 (sec)
+    Verify return code: 18 (self-signed certificate)
+    Extended master secret: no
+    Max Early Data: 0
+---
+read R BLOCK

--- a/submissions/lab4-tls-curl.txt
+++ b/submissions/lab4-tls-curl.txt
@@ -1,0 +1,60 @@
+* Host localhost:8443 was resolved.
+* IPv6: ::1
+* IPv4: 127.0.0.1
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:8443...
+* Connected to localhost (::1) port 8443
+* ALPN: curl offers h2,http/1.1
+} [5 bytes data]
+* TLSv1.3 (OUT), TLS handshake, Client hello (1):
+} [512 bytes data]
+* TLSv1.3 (IN), TLS handshake, Server hello (2):
+{ [122 bytes data]
+* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
+{ [15 bytes data]
+* TLSv1.3 (IN), TLS handshake, Certificate (11):
+{ [816 bytes data]
+* TLSv1.3 (IN), TLS handshake, CERT verify (15):
+{ [264 bytes data]
+* TLSv1.3 (IN), TLS handshake, Finished (20):
+{ [36 bytes data]
+* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
+} [1 bytes data]
+* TLSv1.3 (OUT), TLS handshake, Finished (20):
+} [36 bytes data]
+* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
+* ALPN: server accepted h2
+* Server certificate:
+*  subject: CN=localhost
+*  start date: Jun 16 18:11:03 2026 GMT
+*  expire date: Jun 17 18:11:03 2026 GMT
+*  issuer: CN=localhost
+*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
+*   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
+{ [5 bytes data]
+* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
+{ [122 bytes data]
+* using HTTP/2
+* [HTTP/2] [1] OPENED stream for https://localhost:8443/health
+* [HTTP/2] [1] [:method: GET]
+* [HTTP/2] [1] [:scheme: https]
+* [HTTP/2] [1] [:authority: localhost:8443]
+* [HTTP/2] [1] [:path: /health]
+* [HTTP/2] [1] [user-agent: curl/8.5.0]
+* [HTTP/2] [1] [accept: */*]
+} [5 bytes data]
+> GET /health HTTP/2
+> Host: localhost:8443
+> User-Agent: curl/8.5.0
+> Accept: */*
+> 
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0{ [5 bytes data]
+< HTTP/2 200 
+< content-type: application/json
+< date: Tue, 16 Jun 2026 18:11:07 GMT
+< content-length: 26
+< 
+{ [26 bytes data]
+100    26  100    26    0     0    197      0 --:--:-- --:--:-- --:--:--   200
+* Connection #0 to host localhost left intact

--- a/submissions/lab4-tls.sh
+++ b/submissions/lab4-tls.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Lab 4 Bonus — terminate TLS in front of QuickNotes and capture the handshake.
+# Run from WSL:  echo <pw> | sudo -S -v ; bash submissions/lab4-tls.sh
+# (sudo is needed for tcpdump; warm it once before calling.)
+set -uo pipefail
+export PATH="$HOME/go124/go/bin:/usr/sbin:/usr/bin:/bin:$PATH"
+export GOTOOLCHAIN=local
+
+SUB="/mnt/c/study/DEVOPS/DevOps-Intro/submissions"
+APP="/mnt/c/study/DEVOPS/DevOps-Intro/app"
+W="/tmp/lab4tls"
+rm -rf "$W"; mkdir -p "$W"; cd "$W"
+pkill -f /quicknotes 2>/dev/null; pkill -f lab4-tlsproxy 2>/dev/null; sleep 1
+
+# self-signed cert for localhost
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 1 \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost" >/dev/null 2>&1
+
+exec >"$SUB/lab4-tls-capture.txt" 2>&1   # report to file (bg jobs won't hold the pipe)
+
+echo "=== start QuickNotes (:8080) and TLS proxy (:8443) ==="
+( cd "$APP" && ADDR=:8080 nohup go run . >/tmp/qn.log 2>&1 </dev/null & )
+nohup go run "$SUB/lab4-tlsproxy.go" >/tmp/proxy.log 2>&1 </dev/null &
+disown
+for i in $(seq 1 100); do
+  ss -tln 2>/dev/null | grep -q :8443 && ss -tln 2>/dev/null | grep -q :8080 && break
+  sleep 0.4
+done
+echo "listeners: 8080=$(ss -tln|grep -c :8080)  8443=$(ss -tln|grep -c :8443)"
+echo "proxy.log: $(cat /tmp/proxy.log)"
+
+echo
+echo "=== capture handshake on lo:8443 ==="
+sudo tcpdump -i lo -nn -s0 -w "$W/lab4-tls.pcap" 'tcp port 8443' >/dev/null 2>&1 &
+TPID=$!
+sleep 1.5
+echo "--- curl -vk https://localhost:8443/health (verbose -> lab4-tls-curl.txt) ---"
+curl -vk https://localhost:8443/health 2>"$SUB/lab4-tls-curl.txt"
+echo
+sleep 1.5
+sudo kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
+sudo pkill -f "tcpdump -i lo" 2>/dev/null
+
+cp "$W/lab4-tls.pcap" "$SUB/lab4-tls.pcap" 2>/dev/null
+sudo chown "$(id -un)":"$(id -gn)" "$SUB/lab4-tls.pcap" 2>/dev/null
+
+echo "=== certificate chain (openssl s_client -showcerts) ==="
+echo | openssl s_client -connect localhost:8443 -showcerts 2>/dev/null > "$SUB/lab4-tls-cert.txt"
+openssl x509 -in "$W/cert.pem" -noout -subject -issuer -dates
+
+echo
+echo "=== negotiated session (openssl s_client summary) ==="
+echo | openssl s_client -connect localhost:8443 2>/dev/null \
+  | grep -E "Protocol|Cipher|Server public key|Verify|Verification" | head -8
+
+pkill -f /quicknotes 2>/dev/null; pkill -f lab4-tlsproxy 2>/dev/null
+echo
+echo "=== DONE. pcap: $(ls -la "$SUB/lab4-tls.pcap" 2>/dev/null) ==="

--- a/submissions/lab4-tlsproxy.go
+++ b/submissions/lab4-tlsproxy.go
@@ -1,0 +1,28 @@
+// Lab 4 Bonus — a minimal TLS-terminating reverse proxy.
+// Listens HTTPS on :8443, forwards plaintext to QuickNotes on :8080.
+// Run: go run lab4-tlsproxy.go  (expects cert.pem/key.pem in the working dir)
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+func main() {
+	backend, err := url.Parse("http://127.0.0.1:8080")
+	if err != nil {
+		log.Fatal(err)
+	}
+	srv := &http.Server{
+		Addr:    ":8443",
+		Handler: httputil.NewSingleHostReverseProxy(backend),
+		// Go's defaults: min TLS 1.2, prefers TLS 1.3. We leave them as-is so the
+		// capture shows what a modern server negotiates out of the box.
+		TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	log.Println("TLS proxy listening on :8443 -> http://127.0.0.1:8080")
+	log.Fatal(srv.ListenAndServeTLS("cert.pem", "key.pem"))
+}

--- a/submissions/lab4-trace.txt
+++ b/submissions/lab4-trace.txt
@@ -1,0 +1,49 @@
+20:56:25.497005 IP6 ::1.48708 > ::1.8080: Flags [S], seq 4292351501, win 65476, options [mss 65476,sackOK,TS val 520694204 ecr 0,nop,wscale 7], length 0
+`
+(..(.@.................................D...............0.........
+.	).........
+20:56:25.497018 IP6 ::1.8080 > ::1.48708: Flags [S.], seq 930453344, ack 4292351502, win 65464, options [mss 65476,sackOK,TS val 520694205 ecr 520694204,nop,wscale 7], length 0
+`	0f.(.@...................................D7u.`.........0.........
+.	)..	).....
+20:56:25.497026 IP6 ::1.48708 > ::1.8080: Flags [.], ack 1, win 512, options [nop,nop,TS val 520694205 ecr 520694205], length 0
+`
+(.. .@.................................D......7u.a.....(.....
+.	)..	).
+20:56:25.497409 IP6 ::1.48708 > ::1.8080: Flags [P.], seq 1:175, ack 1, win 512, options [nop,nop,TS val 520694205 ecr 520694205], length 174: HTTP: POST /notes HTTP/1.1
+`
+(....@.................................D......7u.a...........
+.	)..	).POST /notes HTTP/1.1
+Host: localhost:8080
+User-Agent: curl/8.5.0
+Accept: */*
+Content-Type: application/json
+Content-Length: 39
+
+{"title":"trace me","body":"in flight"}
+20:56:25.497435 IP6 ::1.8080 > ::1.48708: Flags [.], ack 175, win 511, options [nop,nop,TS val 520694205 ecr 520694205], length 0
+`	0f. .@...................................D7u.a.........(.....
+.	)..	).
+20:56:25.504287 IP6 ::1.8080 > ::1.48708: Flags [P.], seq 1:206, ack 175, win 512, options [nop,nop,TS val 520694212 ecr 520694205], length 205: HTTP: HTTP/1.1 201 Created
+`	0f...@...................................D7u.a...............
+.	)..	).HTTP/1.1 201 Created
+Content-Type: application/json
+Date: Tue, 16 Jun 2026 17:56:25 GMT
+Content-Length: 92
+
+{"id":8,"title":"trace me","body":"in flight","created_at":"2026-06-16T17:56:25.49840222Z"}
+
+20:56:25.504320 IP6 ::1.48708 > ::1.8080: Flags [.], ack 206, win 511, options [nop,nop,TS val 520694212 ecr 520694212], length 0
+`
+(.. .@.................................D......7u.......(.....
+.	)..	).
+20:56:25.506147 IP6 ::1.48708 > ::1.8080: Flags [F.], seq 175, ack 206, win 512, options [nop,nop,TS val 520694214 ecr 520694212], length 0
+`
+(.. .@.................................D......7u.......(.....
+.	)..	).
+20:56:25.506282 IP6 ::1.8080 > ::1.48708: Flags [F.], seq 206, ack 176, win 512, options [nop,nop,TS val 520694214 ecr 520694214], length 0
+`	0f. .@...................................D7u...........(.....
+.	)..	).
+20:56:25.506304 IP6 ::1.48708 > ::1.8080: Flags [.], ack 207, win 512, options [nop,nop,TS val 520694214 ecr 520694214], length 0
+`
+(.. .@.................................D......7u./.....(.....
+.	)..	).

--- a/submissions/lab4.md
+++ b/submissions/lab4.md
@@ -1,0 +1,262 @@
+# Lab 4 — OS & Networking: Trace, Debug, and Read the Substrate
+
+Environment: Windows 11 host + **WSL2 (Ubuntu, kernel 6.6)**. QuickNotes runs in
+WSL on `:8080`; all captures and tools (`tcpdump`, `ss`, `dig`, `mtr`,
+`journalctl`) run inside WSL. The full capture sequence is scripted in
+[`lab4-capture.sh`](lab4-capture.sh).
+
+> Note on Go: WSL's system Go is 1.22 but QuickNotes' `go.mod` requires 1.24, so
+> a user-local Go 1.24 (`~/go124`) is used with `GOTOOLCHAIN=local`.
+
+---
+
+## Task 1 — Trace a Request End-to-End
+
+### 1.1–1.2: Capture + decode
+
+One `POST /notes` was captured on `lo` and decoded. `curl` resolved `localhost`
+to **IPv6 `::1`**, so the whole exchange rides the IPv6 loopback. Raw capture:
+[`lab4-trace.txt`](lab4-trace.txt); verbose client side:
+[`lab4-curl.txt`](lab4-curl.txt). Annotated (timestamps trimmed, byte-dumps
+removed):
+
+```text
+# ── TCP three-way handshake ───────────────────────────────────────────
+::1.48708 > ::1.8080: Flags [S],  seq 4292351501                       # SYN
+::1.8080 > ::1.48708: Flags [S.], seq 930453344, ack 4292351502        # SYN/ACK
+::1.48708 > ::1.8080: Flags [.],  ack 1                                 # ACK  → connection established
+
+# ── HTTP request (client → server) ────────────────────────────────────
+::1.48708 > ::1.8080: Flags [P.], seq 1:175, length 174: POST /notes HTTP/1.1
+    Host: localhost:8080
+    Content-Type: application/json
+    Content-Length: 39
+
+    {"title":"trace me","body":"in flight"}
+::1.8080 > ::1.48708: Flags [.], ack 175                               # server ACKs the request bytes
+
+# ── HTTP response (server → client) ───────────────────────────────────
+::1.8080 > ::1.48708: Flags [P.], seq 1:206, length 205: HTTP/1.1 201 Created
+    Content-Type: application/json
+    Content-Length: 92
+
+    {"id":8,"title":"trace me","body":"in flight","created_at":"2026-06-16T17:56:25.49840222Z"}
+::1.48708 > ::1.8080: Flags [.], ack 206                               # client ACKs the response
+
+# ── Connection close (graceful 4-way FIN) ─────────────────────────────
+::1.48708 > ::1.8080: Flags [F.], seq 175, ack 206                     # client FIN
+::1.8080 > ::1.48708: Flags [F.], seq 206, ack 176                     # server FIN
+::1.48708 > ::1.8080: Flags [.],  ack 207                              # client final ACK → closed
+```
+
+The whole request/response completed in ~9 ms (`20:56:25.497005` →
+`20:56:25.506304`). Note Go's HTTP server sent the response and then the client
+initiated the close (`FIN`), a clean shutdown — no `RST`.
+
+### 1.3: The five debugging commands
+
+```text
+### 1. ss -tlnp | grep :8080   — what's listening?
+LISTEN 0  4096  *:8080  *:*  users:(("quicknotes",pid=1300,fd=3))
+
+### 2. ip route show           — routes from this host
+default via 172.28.16.1 dev eth0 proto kernel
+172.28.16.0/20 dev eth0 proto kernel scope link src 172.28.27.7
+
+### 3. mtr -rwc 5 localhost     — reachability over lo
+HOST: rikire    Loss%  Snt  Last  Avg  Best  Wrst StDev
+  1.|-- localhost  0.0%    5   0.0  0.0   0.0   0.0   0.0
+
+### 4. dig +short example.com @1.1.1.1   — DNS works?
+172.66.147.243
+104.20.23.154
+
+### 5. journalctl --user -u quicknotes -n 20   — service logs
+-- No entries --
+```
+
+Reading them:
+- **`ss`** confirms `quicknotes` (pid 1300) owns `:8080` on all interfaces
+  (`*:8080`) — that's why both `::1` and `127.0.0.1` connect.
+- **`ip route`** shows WSL's NAT'd network: default gateway `172.28.16.1` on
+  `eth0`. Loopback traffic to `::1`/`127.0.0.1` never touches this route.
+- **`mtr`** to `localhost` is a single hop with **0% loss** — `lo` is healthy.
+- **`dig`** resolves `example.com` via Cloudflare's `1.1.1.1` — external DNS
+  works, so a name-resolution failure isn't on the table.
+- **`journalctl --user -u quicknotes`** is empty because QuickNotes runs via
+  `go run`, not as a systemd unit — there is no journald unit, its logs go to
+  stdout. (Documented, not an error.)
+
+### 1.4: What would I check first if QuickNotes returned 502?
+
+A **502 Bad Gateway comes from a reverse proxy in front of the app, not from the
+app itself** — it means the proxy could not get a valid response from its
+upstream. So my first move is to stop trusting the proxy's error and check the
+upstream directly. I'd run `ss -tlnp | grep :8080` to confirm QuickNotes is
+actually *listening* and on the address the proxy expects (a classic 502 is the
+app bound to `127.0.0.1` while the proxy dials it on another interface, or the
+process having crashed and nothing listening at all). Then I'd `curl -v` the app
+**directly, bypassing the proxy** — if that returns `201/200`, the fault is the
+proxy's upstream config or a timeout; if it fails too, the app is the problem and
+I go to its logs (stdout / `journalctl`). In short: confirm *listening →
+reachable directly → app logs*, in that order, and only then look at the proxy's
+own config and logs.
+
+---
+
+## Task 2 — Outside-In Debugging on a Broken Deploy
+
+Scripted in [`lab4-debug.sh`](lab4-debug.sh); raw output in
+[`lab4-task2.txt`](lab4-task2.txt).
+
+### 2.1: The broken instance
+
+Two instances were started on the same port. The first binds `:8080`; the second
+fails immediately:
+
+```text
+2026/06/16 21:04:17 quicknotes listening on :8080 (notes loaded: 8)
+2026/06/16 21:04:17 listen: listen tcp :8080: bind: address already in use
+exit status 1   # second instance, exit code 1
+```
+
+(QuickNotes logs "listening" *before* it actually calls `ListenAndServe`, so the
+optimistic line prints first and the real bind error follows — a small logging
+gotcha worth knowing when reading these traces.)
+
+### 2.2: The outside-in chain
+
+| Step | Command | Output | Decision |
+|------|---------|--------|----------|
+| 1. Running? | `ps -ef \| grep quicknotes` | `go run .` (pid 1795) + child binary `quicknotes` (pid 1898) | A process *is* up — move inward. |
+| 2. Listening? | `ss -tlnp \| grep 8080` | `LISTEN *:8080 users:(("quicknotes",pid=1898,fd=3))` | Socket is bound by pid 1898. Not a "nothing listening" case. |
+| 3. Reachable? | `curl -s -o /dev/null -w "%{http_code}" …/health` | `HTTP 200` | The *surviving* instance is healthy and serving. |
+| 4. Firewall? | `sudo iptables -L -n -v` / `nft list ruleset` | _(see below)_ | Rule out L3/L4 filtering. |
+| 5. DNS? | `dig +short localhost` | `127.0.0.1` (from `/etc/hosts`) | Name resolution is fine — not DNS. |
+
+Step 4 — firewall ruleset (needs root):
+
+```text
+$ sudo iptables -L -n -v; sudo nft list ruleset
+sudo: iptables: command not found
+sudo: nft: command not found
+```
+
+On this WSL2 instance neither `iptables` nor `nft` is installed, so there is **no
+packet-filtering layer at all** — a firewall can't be blocking traffic because
+there's nothing here to enforce rules. That immediately rules out L3/L4 filtering
+as a cause.
+
+**Conclusion of the chain:** every layer for the *running* instance is green
+(process up → listening → reachable → no firewall → DNS fine). The "broken
+deploy" is the **second** process, which never got to serve because the port was
+already owned. The outside-in walk localizes the fault to **bind time**, not the
+network or DNS.
+
+### 2.3: Repair + re-verify
+
+Kill the conflicting instance, restart a single one, re-check health:
+
+```text
+after repair, /health = {"notes":8,"status":"ok"}
+```
+
+### Root cause
+
+`listen tcp :8080: bind: address already in use` — a **port conflict**: two
+processes were told to own the same TCP port; the kernel grants `:8080` to the
+first to `bind()` and rejects the second with `EADDRINUSE`.
+
+### Mini-postmortem (blameless)
+
+*What happened.* A second QuickNotes process was started on a port the first
+already held; it exited non-zero with `EADDRINUSE` and served no traffic.
+
+*What's systemic — not a person's mistake.* Nothing **prevented** launching a
+second copy onto an occupied port, and the only signal was one easily-missed log
+line. Manual `go run`/`./binary` starts have no notion of "this service already
+runs here," no health gate, no restart policy. The failure is latent in *how the
+service is run*, not in who ran it.
+
+*What tooling would prevent it.* Run it under a supervisor — a **systemd unit**
+on a fixed port can't be silently double-started: the second start fails loudly
+in `systemctl status` / `journalctl`. Add a **pre-flight port check** and a
+**readiness probe** to deploy scripts so "didn't bind" surfaces at once.
+**Containerizing** gives each instance its own network namespace, or a port
+mapping that conflicts loudly at `docker run`. A **rolling deploy with health
+checks** replaces "start another copy and hope" with "start, verify, shift
+traffic." Make the conflict impossible, or impossible to ignore — never "be more
+careful."
+
+## Bonus — Decode the TLS Handshake
+
+QuickNotes speaks plaintext HTTP, so I put a **TLS-terminating reverse proxy** in
+front of it. Instead of Caddy (not in Ubuntu's default repos) I used a 20-line Go
+proxy ([`lab4-tlsproxy.go`](lab4-tlsproxy.go)) with a self-signed cert — fewer
+moving parts, same handshake. I decoded the capture with **`tshark` (CLI)** and
+**`openssl s_client`** rather than the Wireshark GUI; the data is identical.
+Scripted in [`lab4-tls.sh`](lab4-tls.sh).
+
+```text
+:8443  (Go TLS reverse proxy, terminates TLS)  ──►  :8080  (QuickNotes, plain HTTP)
+```
+
+`curl -vk https://localhost:8443/health` → `{"notes":8,"status":"ok"}` — TLS
+terminated, request proxied, `200 OK` over HTTP/2. Full client trace:
+[`lab4-tls-curl.txt`](lab4-tls-curl.txt); cert dump:
+[`lab4-tls-cert.txt`](lab4-tls-cert.txt).
+
+### ClientHello (frame 4)
+
+| Field | Value |
+|-------|-------|
+| SNI (`server_name`) | `localhost` |
+| `legacy_version` | TLS 1.2 (`0x0303`) — frozen by spec; record layer even shows `0x0301` for middlebox compat |
+| **`supported_versions` ext** | **TLS 1.3 (`0x0304`), TLS 1.2 (`0x0303`)** — note: **no 1.0/1.1 offered** |
+| Cipher suites offered | 35 total: the three TLS 1.3 AEAD suites (`TLS_AES_256_GCM_SHA384`, `TLS_CHACHA20_POLY1305_SHA256`, `TLS_AES_128_GCM_SHA256`) followed by TLS 1.2 ECDHE/DHE/RSA suites |
+
+### ServerHello (frame 6)
+
+| Field | Value |
+|-------|-------|
+| `legacy_version` | TLS 1.2 (`0x0303`) |
+| **`supported_versions` ext (selected)** | **TLS 1.3 (`0x0304`)** |
+| Chosen cipher | **`TLS_AES_128_GCM_SHA256` (`0x1301`)** |
+| Key exchange / sig (from `curl`/`openssl`) | X25519 ECDHE / RSASSA-PSS |
+
+Negotiated result (`curl` + `openssl s_client`):
+`TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS`, ALPN → `h2`.
+
+### Certificate chain
+
+```text
+subject = CN = localhost
+issuer  = CN = localhost          # self-signed (verify code 18)
+Public key: RSA 2048, signed with sha256WithRSAEncryption
+notBefore = Jun 16 18:11:03 2026 GMT
+notAfter  = Jun 17 18:11:03 2026 GMT   # 1-day cert
+```
+
+**Why the cert came from `openssl`/`curl`, not the pcap:** in TLS 1.3 the
+`Certificate` message is sent **inside the encrypted flight** (after
+ServerHello + key exchange), so it is *not* visible as plaintext in
+`lab4-tls.pcap` — `tshark` only sees `Application Data`. That's exactly why the
+task pairs the capture with `openssl s_client -showcerts`: the cert chain lives
+behind encryption now. (Under TLS 1.2 the certificate was sent in the clear.)
+
+### Which negotiation step kills TLS 1.0 / 1.1 in 2026?
+
+The **`supported_versions` extension (RFC 8446)**. Since TLS 1.3, the real
+version is no longer the `legacy_version` field in the record/handshake header —
+that's permanently pinned to `0x0303` (TLS 1.2) for backward compatibility with
+old middleboxes. The actual negotiation happens in `supported_versions`: the
+client lists the versions it will accept, and the server picks one from that
+list. In this capture the client advertised **only `0x0304` and `0x0303`** — TLS
+1.0 (`0x0301`) and 1.1 (`0x0302`) are simply absent — and the Go server sets
+`MinVersion: TLS 1.2`. So a 1.0/1.1 session can never be selected: the client
+won't offer it and the server won't accept it. The deprecation is enforced *at
+the `supported_versions` step*, by both ends refusing to put the old versions on
+the table — not by some later "downgrade" rejection.
+
+> Optional: the same handshake can be opened in the Wireshark GUI from
+> `lab4-tls.pcap` for screenshots; the CLI decode above is the same data.


### PR DESCRIPTION
## Goal
Trace one POST /notes end-to-end, debug a broken deploy outside-in, and decode a TLS handshake in front of QuickNotes.

## Changes
- Task 1: annotated `lo` packet capture (3-way handshake → POST /notes + JSON → 201 Created → FIN close), five debug commands (ss/ip route/mtr/dig/journalctl), and a 502-debugging reflection.
- Task 2: reproduced `bind: address already in use` (two instances on :8080), full outside-in chain (process → listening → reachable → firewall → DNS) with a decision at each step, root cause, and a blameless mini-postmortem (≤200 words).
- Bonus: Go TLS-terminating reverse proxy (:8443 → :8080) + self-signed cert; TLS 1.3 handshake decoded via tshark/openssl (ClientHello/ServerHello/cipher), certificate chain, and why supported_versions kills TLS 1.0/1.1 in 2026.
- Artifacts: `lab4-trace.txt`, `lab4-curl.txt`, `lab4-commands.txt`, `lab4-task2.txt`, `lab4-tls-*.txt`, helper scripts.

## Testing
- Capture verified to contain handshake, HTTP request/response, and close.
- Broken instance reproduced and repaired (`/health` returns `{"status":"ok"}`); chain re-verified.
- TLS endpoint negotiated `TLSv1.3 / TLS_AES_128_GCM_SHA256`; cert chain confirmed via `openssl s_client`.

## Checklist
- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/lab4.md` updated
