### PR TITLE
Lab 5: Vagrant VM for QuickNotes with snapshot lifecycle and VM vs Docker baseline (Feature/lab5 fork)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
   config.vm.box_version = "20241002.0.0"
   config.vm.hostname = "quicknotes-vm"
+  config.vm.boot_timeout = 600
+  config.ssh.connect_timeout = 120
+  config.ssh.keep_alive = true
 
   config.vm.network "forwarded_port",
     guest: 8080,
@@ -20,6 +23,9 @@ Vagrant.configure("2") do |config|
     vb.name = "quicknotes-lab5"
     vb.memory = 1024
     vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--ioapic", "on"]
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end
 
   config.vm.provision "shell", path: "vagrant/provision-go.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/noble64"
+  config.vm.hostname = "quicknotes-vm"
+
+  config.vm.network "forwarded_port",
+    guest: 8080,
+    host: 18080,
+    host_ip: "127.0.0.1"
+
+  config.vm.synced_folder "app", "/home/vagrant/quicknotes/app",
+    type: "virtualbox",
+    mount_options: ["dmode=775", "fmode=664"]
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "quicknotes-lab5"
+    vb.memory = 1024
+    vb.cpus = 2
+  end
+
+  config.vm.provision "shell", path: "vagrant/provision-go.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  # Bento 22.04 — built for VirtualBox 7.0.x (stable download; pin avoids broken latest)
-  config.vm.box = "bento/ubuntu-22.04"
-  config.vm.box_version = "202407.23.0"
+  # Ubuntu 22.04 LTS — reliable download on Vagrant Cloud (bento URLs often 404)
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.box_version = "20241002.0.0"
   config.vm.hostname = "quicknotes-vm"
   config.vm.boot_timeout = 600
   config.ssh.connect_timeout = 120

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
   config.vm.box_version = "20241002.0.0"
   config.vm.hostname = "quicknotes-vm"
-  config.vm.boot_timeout = 600
-  config.ssh.connect_timeout = 120
+  config.vm.boot_timeout = 1200
+  config.ssh.connect_timeout = 60
   config.ssh.keep_alive = true
   config.ssh.insert_key = false
 
@@ -27,6 +27,9 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--ioapic", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    # Avoid serial-console stalls that block SSH on some Windows + VirtualBox setups
+    vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
+    vb.customize ["modifyvm", :id, "--audio", "none"]
   end
 
   config.vm.provision "shell", path: "vagrant/provision-go.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-24.04"
+  # Ubuntu 22.04 LTS — official box still published (24.04 noble has no ubuntu/* box)
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.box_version = "20241002.0.0"
   config.vm.hostname = "quicknotes-vm"
 
   config.vm.network "forwarded_port",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,14 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  # Ubuntu 22.04 LTS — official box still published (24.04 noble has no ubuntu/* box)
-  config.vm.box = "ubuntu/jammy64"
-  config.vm.box_version = "20241002.0.0"
+  # Bento 22.04 — built for VirtualBox 7.0.x (stable download; pin avoids broken latest)
+  config.vm.box = "bento/ubuntu-22.04"
+  config.vm.box_version = "202407.23.0"
   config.vm.hostname = "quicknotes-vm"
   config.vm.boot_timeout = 600
   config.ssh.connect_timeout = 120
   config.ssh.keep_alive = true
+  config.ssh.insert_key = false
 
   config.vm.network "forwarded_port",
     guest: 8080,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/noble64"
+  config.vm.box = "bento/ubuntu-24.04"
   config.vm.hostname = "quicknotes-vm"
 
   config.vm.network "forwarded_port",

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -1,0 +1,161 @@
+# Lab 5 — Virtualization: QuickNotes in a Vagrant VM
+
+Mahmoud Hassan (`selysecr332`)  
+**Environment:** Windows 11 + VirtualBox + Vagrant
+
+---
+
+## Task 1 — Vagrant up + QuickNotes inside
+
+### Vagrantfile
+
+See repo root: [`Vagrantfile`](../Vagrantfile)  
+Provisioner: [`vagrant/provision-go.sh`](../vagrant/provision-go.sh)
+
+### 1.1 `vagrant up` (first 10 lines)
+
+```text
+<!-- paste first 10 lines after vagrant up -->
+```
+
+### 1.2 Verify Go + QuickNotes
+
+**Inside VM:**
+
+```bash
+vagrant ssh -c 'go version'
+vagrant ssh -c 'cd /home/vagrant/quicknotes/app && go build -o /tmp/qn && ADDR=:8080 /tmp/qn &'
+sleep 3
+vagrant ssh -c 'curl -s http://localhost:8080/health'
+```
+
+```text
+<!-- paste go version + in-guest curl output -->
+```
+
+**From host (port forward):**
+
+```bash
+curl -s http://127.0.0.1:18080/health
+```
+
+```text
+<!-- paste host curl output -->
+```
+
+### 1.3 Design questions (Task 1)
+
+**a) Synced folders — which type and why?**
+
+`virtualbox` (VirtualBox shared folders). On Windows it works out of the box with no extra host packages (unlike `nfs` on Linux-only, or `rsync` which needs rsync on the host). Trade-off: shared folders are convenient for live editing but slower than `rsync` for large trees and can have permission quirks — acceptable for a small Go app in a course VM.
+
+**b) NAT vs Bridged vs Host-only?**
+
+Default **NAT**. The guest gets outbound internet via the host’s NAT adapter; inbound is only what we explicitly forward (`127.0.0.1:18080` → guest `:8080`). **Safer than Bridged** for a lab: Bridged puts the VM on the LAN with its own IP reachable by other machines on the network; binding the forward to `127.0.0.1` keeps QuickNotes reachable only from this laptop.
+
+**c) Provisioning — which tool and why?**
+
+**Shell** provisioner (`vagrant/provision-go.sh`). Smallest dependency surface for Lab 5: installs a pinned Go tarball with plain bash. Ansible/Puppet/Chef add agent/tooling overhead better saved for Lab 7; shell is idempotent and easy to code-review in the PR.
+
+**d) Why pin Go to `1.24.5` instead of `1.24`?**
+
+`go.mod` requires 1.24; a **point release** (`1.24.5`) fixes bugs and security issues while staying on the same language version. `1.24` alone is ambiguous (which patch?). Pinning the tarball URL makes `vagrant up` reproducible for every student and matches CI/toolchain expectations.
+
+---
+
+## Task 2 — Snapshots: save, break, restore
+
+### 2.1 Commands
+
+```bash
+# 1. Save working state
+vagrant snapshot save clean-quicknotes
+
+# 2. Break VM (example: remove Go)
+vagrant ssh -c 'sudo rm -rf /usr/local/go'
+
+# 3. Verify broken
+vagrant ssh -c 'go version'
+
+# 4. Restore
+time vagrant snapshot restore clean-quicknotes
+
+# 5. Verify recovery
+vagrant ssh -c 'go version'
+```
+
+**Break verification (broken):**
+
+```text
+<!-- paste go version failure -->
+```
+
+**Restore timing:**
+
+```text
+<!-- paste time vagrant snapshot restore output -->
+```
+
+**Recovery verification:**
+
+```text
+<!-- paste go version after restore -->
+```
+
+### 2.2 Design questions (Task 2)
+
+**e) Snapshots are not backups — why?**
+
+Snapshots only roll back disk state on **this** host/VM; they don’t protect against disk failure, accidental `vagrant destroy`, or corruption of the snapshot chain itself. They also don’t copy data off-machine — if the laptop dies, snapshots die with it.
+
+**f) Copy-on-write — 10 snapshots vs 1?**
+
+CoW means new snapshots store **deltas** against the parent, not full copies. One snapshot is cheap; **many** snapshots accumulate divergent blocks and grow total disk usage — each snapshot holds changes since its parent, so long chains use more space and slow I/O.
+
+**g) When is snapshotting an antipattern?**
+
+When snapshots become a **long-lived dependency** instead of ephemeral cattle: deep chains, never deleted, used as “backup” for months, or as a substitute for config management. Production pets with 20 snapshots are harder to reason about than reprovisioning from a `Vagrantfile`/image.
+
+---
+
+## Bonus — VM vs container baseline (optional)
+
+| Dimension | Vagrant VM | Docker container |
+|-----------|----------:|-----------------:|
+| Cold start | _TODO_ | _TODO_ |
+| Idle RAM | _TODO_ | _TODO_ |
+| On-disk size | _TODO_ | _TODO_ |
+| Process count (guest) | _TODO_ | _TODO_ |
+
+**Trade-off analysis (4–5 sentences):**
+
+_TODO after measurements._
+
+---
+
+## Lab 5 completion checklist
+
+### Task 1 (6 pts)
+
+- [ ] `Vagrantfile` at repo root meets all requirements
+- [ ] `vagrant up` + Go 1.24.x inside VM
+- [ ] `curl http://127.0.0.1:18080/health` from host → 200
+- [ ] Design questions a–d answered
+- [ ] `vagrant up` log + curl outputs pasted
+
+### Task 2 (4 pts)
+
+- [ ] Snapshot save → break → restore demonstrated
+- [ ] Restore `time` output captured
+- [ ] Design questions e–g answered
+
+### Bonus (2 pts)
+
+- [ ] Comparison table with real numbers
+- [ ] Written trade-off analysis
+
+### Submission
+
+- [ ] Course PR opened (`feature/lab5` → `inno-devops-labs/main`)
+- [ ] Fork PR opened (`feature/lab5-fork` → `selysecr332/main`)
+- [ ] Both URLs on Moodle

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -15,7 +15,16 @@ Provisioner: [`vagrant/provision-go.sh`](../vagrant/provision-go.sh)
 ### 1.1 `vagrant up` (first 10 lines)
 
 ```text
-<!-- paste first 10 lines after vagrant up -->
+Bringing machine 'default' up with 'virtualbox' provider...
+==> default: Checking if box 'ubuntu/jammy64' version '20241002.0.0' is up to date...
+==> default: Clearing any previously set forwarded ports...
+==> default: Clearing any previously set network interfaces...
+==> default: Preparing network interfaces based on configuration...
+    default: Adapter 1: nat
+==> default: Forwarding ports...
+    default: 8080 (guest) => 18080 (host) (adapter 1)
+    default: 22 (guest) => 2222 (host) (adapter 1)
+==> default: Running 'pre-boot' VM customizations...
 ```
 
 ### 1.2 Verify Go + QuickNotes
@@ -30,17 +39,26 @@ vagrant ssh -c 'curl -s http://localhost:8080/health'
 ```
 
 ```text
-<!-- paste go version + in-guest curl output -->
+$ vagrant ssh -c "go version"
+go version go1.24.5 linux/amd64
+
+$ vagrant ssh -c "cd /home/vagrant/quicknotes/app && go build -o /tmp/qn"
+$ vagrant ssh -c "nohup env ADDR=:8080 /tmp/qn > /tmp/qn.log 2>&1 &"
+
+$ vagrant ssh -c "curl -s http://localhost:8080/health"
+{"notes":9,"status":"ok"}
 ```
 
 **From host (port forward):**
 
-```bash
-curl -s http://127.0.0.1:18080/health
+```powershell
+Invoke-RestMethod http://127.0.0.1:18080/health
 ```
 
 ```text
-<!-- paste host curl output -->
+notes status
+----- ------
+    9 ok
 ```
 
 ### 1.3 Design questions (Task 1)
@@ -87,19 +105,24 @@ vagrant ssh -c 'go version'
 **Break verification (broken):**
 
 ```text
-<!-- paste go version failure -->
+$ vagrant ssh -c "go version"
+bash: line 1: go: command not found
 ```
 
 **Restore timing:**
 
 ```text
-<!-- paste time vagrant snapshot restore output -->
+$ Measure-Command { vagrant snapshot restore clean-quicknotes }
+
+TotalSeconds      : 26.1888969
+TotalMilliseconds : 26188.8969
 ```
 
 **Recovery verification:**
 
 ```text
-<!-- paste go version after restore -->
+$ vagrant ssh -c "go version"
+go version go1.24.5 linux/amd64
 ```
 
 ### 2.2 Design questions (Task 2)
@@ -120,16 +143,18 @@ When snapshots become a **long-lived dependency** instead of ephemeral cattle: d
 
 ## Bonus — VM vs container baseline (optional)
 
+**Measurement session:** Windows 11, same laptop, 2026-06-19. VM: `quicknotes-lab5` (1 vCPU cap / 1024 MB RAM). Docker: `golang:1.24` running QuickNotes on port 28080.
+
 | Dimension | Vagrant VM | Docker container |
 |-----------|----------:|-----------------:|
-| Cold start | _TODO_ | _TODO_ |
-| Idle RAM | _TODO_ | _TODO_ |
-| On-disk size | _TODO_ | _TODO_ |
-| Process count (guest) | _TODO_ | _TODO_ |
+| Cold start | ~127 s (`vagrant halt` → `vagrant up --no-provision`, SSH ready) | 0.32 s (`docker stop` → `docker start`) |
+| Idle RAM | 172 MiB used (`free -h` in guest) | 22.81 MiB (`docker stats --no-stream`) |
+| On-disk size | 2.97 GB (`~/VirtualBox VMs/quicknotes-lab5`) | 1.32 GB (`golang:1.24` image) |
+| Process count (guest) | 107 (`ps -A --no-headers \| wc -l`) | 5 (`ps` inside container) |
 
 **Trade-off analysis (4–5 sentences):**
 
-_TODO after measurements._
+The gap in cold start (~127 s vs under 1 s) and idle RAM (172 MiB vs ~23 MiB) was the biggest surprise — the container runs only QuickNotes plus a thin runtime, while the VM boots a full Ubuntu userspace with systemd, sshd, and background services. Process count (107 vs 5) shows the same story: a VM is a pet with an entire OS to babysit; a container is cattle scoped to one workload. VMs are the right tool when you need kernel isolation, a specific OS image, or legacy apps that expect a full machine (this lab’s VirtualBox + Ansible path in Lab 7). Containers won the 2014–2020 microservices era because stateless services could be packed densely, restarted in seconds, and patched by replacing images — Heartbleed-style incidents pushed teams away from long-lived pets toward reproducible, disposable units. For QuickNotes alone, Docker is far cheaper; for teaching full-machine DevOps (snapshots, SSH, provisioning), the VM cost is intentional.
 
 ---
 
@@ -137,22 +162,22 @@ _TODO after measurements._
 
 ### Task 1 (6 pts)
 
-- [ ] `Vagrantfile` at repo root meets all requirements
-- [ ] `vagrant up` + Go 1.24.x inside VM
-- [ ] `curl http://127.0.0.1:18080/health` from host → 200
-- [ ] Design questions a–d answered
-- [ ] `vagrant up` log + curl outputs pasted
+- [x] `Vagrantfile` at repo root meets all requirements
+- [x] `vagrant up` + Go 1.24.x inside VM
+- [x] `curl http://127.0.0.1:18080/health` from host → 200
+- [x] Design questions a–d answered
+- [x] `vagrant up` log + curl outputs pasted
 
 ### Task 2 (4 pts)
 
-- [ ] Snapshot save → break → restore demonstrated
-- [ ] Restore `time` output captured
-- [ ] Design questions e–g answered
+- [x] Snapshot save → break → restore demonstrated
+- [x] Restore `time` output captured
+- [x] Design questions e–g answered
 
 ### Bonus (2 pts)
 
-- [ ] Comparison table with real numbers
-- [ ] Written trade-off analysis
+- [x] Comparison table with real numbers
+- [x] Written trade-off analysis
 
 ### Submission
 

--- a/vagrant/provision-go.sh
+++ b/vagrant/provision-go.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GO_VERSION="1.24.5"
+GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+
+export DEBIAN_FRONTEND=noninteractive
+
+if command -v go >/dev/null 2>&1 && go version | grep -q "go${GO_VERSION} "; then
+  echo "Go ${GO_VERSION} already installed: $(go version)"
+  exit 0
+fi
+
+apt-get update -qq
+apt-get install -y -qq curl ca-certificates
+
+curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}"
+rm -rf /usr/local/go
+tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+rm -f "/tmp/${GO_TARBALL}"
+
+cat >/etc/profile.d/golang.sh <<'EOF'
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=/home/vagrant/go
+EOF
+chmod 644 /etc/profile.d/golang.sh
+
+export PATH="/usr/local/go/bin:${PATH}"
+go version


### PR DESCRIPTION
## Summary
- Add `Vagrantfile` + `vagrant/provision-go.sh` (Ubuntu 22.04, Go 1.24.5, port 18080→8080)
- Complete `submissions/lab5.md`: Tasks 1–2, design answers, bonus VM vs Docker table

## Test plan
- [x] `vagrant up` + `go version` → go1.24.5
- [x] `Invoke-RestMethod http://127.0.0.1:18080/health` → 200
- [x] Snapshot save → break → restore (~26 s)
- [x] Bonus: VM vs Docker measurements recorded