### PR TITLE
Lab 6: Dockerize QuickNotes with multi-stage build and compose

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,27 @@
+# builder stage
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-s -w' -o /out/quicknotes
+
+# runtime stage
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /app
+
+COPY --from=builder /out/quicknotes /quicknotes
+
+COPY --from=builder /src/seed.json ./seed.json
+
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/quicknotes"]

--- a/app/main.go
+++ b/app/main.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -12,6 +15,28 @@ import (
 )
 
 func main() {
+
+	healthcheck := flag.Bool("healthcheck", false, "probe /health and exit 0/1")
+	flag.Parse()
+	if *healthcheck {
+		port := os.Getenv("ADDR")
+		if port == "" {
+			port = ":8080"
+		}
+		resp, err := http.Get("http://localhost" + port + "/health")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "healthcheck: %v\n", err)
+			os.Exit(1)
+		}
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			fmt.Fprintf(os.Stderr, "healthcheck: status %d\n", resp.StatusCode)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+	
 	addr := envOrDefault("ADDR", ":8080")
 	dataPath := envOrDefault("DATA_PATH", "data/notes.json")
 	seedPath := envOrDefault("SEED_PATH", "seed.json")

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,4 @@
 services:
-  # One-shot init: fixes ownership of the named volume so the nonroot app
-  # (UID 65532) can write to /data. Runs to completion before quicknotes starts.
   init-data:
     image: busybox:1.36
     command: ["sh", "-c", "chown -R 65532:65532 /data"]
@@ -29,6 +27,14 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
+    #Security hardening (Bonus)
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
 volumes:
   quicknotes-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,34 @@
+services:
+  # One-shot init: fixes ownership of the named volume so the nonroot app
+  # (UID 65532) can write to /data. Runs to completion before quicknotes starts.
+  init-data:
+    image: busybox:1.36
+    command: ["sh", "-c", "chown -R 65532:65532 /data"]
+    volumes:
+      - quicknotes-data:/data
+    restart: "no"
+
+  quicknotes:
+    build: ./app
+    image: quicknotes:lab6
+    depends_on:
+      init-data:
+        condition: service_completed_successfully
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/app/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/quicknotes", "-healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,267 @@
+# Lab 6 Submission
+
+## Task 1 — Multi-Stage Dockerfile
+
+### Dockerfile (`app/Dockerfile`)
+
+```dockerfile
+# builder stage
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-s -w' -o /out/quicknotes
+
+# runtime stage
+FROM gcr.io/distroless/static:nonroot
+
+WORKDIR /app
+
+COPY --from=builder /out/quicknotes /quicknotes
+
+COPY --from=builder /src/seed.json ./seed.json
+
+
+EXPOSE 8080
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/quicknotes"]
+```
+
+
+### Image Size Verification
+
+```bash
+$ docker images quicknotes:lab6
+IMAGE             ID             DISK USAGE   CONTENT SIZE   EXTRA
+quicknotes:lab6   f2ca1d6c0dc6       15.5MB         3.55MB
+```
+
+**Result: 15.5 MB <= 25 MB**
+
+### Docker Inspect Output
+
+```bash
+$ docker inspect quicknotes:lab6 --format '{{json .Config}}'
+{"User":"nonroot:nonroot","ExposedPorts":{"8080/tcp":{}},"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"],"Entrypoint":["/quicknotes"],"WorkingDir":"/app"}
+```
+
+### Base Image Comparison
+
+- `golang:1.24-alpine`: **395 MB**
+- `quicknotes:lab6` (distroless/static:nonroot): **15.5 MB**
+
+**Reduction: 96%**
+
+### Design Questions
+
+**a) Why does layer-order matter?**
+
+Layer order determines cache reuse efficiency. Dependencies change rarely; source code changes often.
+
+**Strategy 1 (BAD):**
+```dockerfile
+COPY . .
+RUN go mod download
+RUN go build
+```
+Any source code change invalidates the `go mod download` layer -> full re-download of all dependencies (rebuild takes more time).
+
+**Strategy 2 (GOOD):**
+```dockerfile
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN go build
+```
+Source code change only invalidates the last two layers; dependencies stay cached (much faster rebuild).
+
+
+
+**b) Why `CGO_ENABLED=0`? What happens in distroless-static if you forget it?**
+
+`CGO_ENABLED=0` produces a statically-linked binary with no external dependencies. Distroless-static contains no libc and no dynamic linker (`/lib/ld-linux.so`).
+
+If you forget `CGO_ENABLED=0`:
+- Go builds a dynamically-linked binary that expects `/lib/ld-linux.so` to exist
+- Distroless-static doesn't have it
+- Container fails at startup with: `exec: no such file or directory`
+- The binary exists but the dynamic linker it needs is missing
+
+**c) What is `gcr.io/distroless/static:nonroot`?**
+
+A minimal base image from Google containing only the runtime artifacts needed to run a static binary:
+- Static binary runtime (nothing else)
+- No shell (`sh`, `bash`)
+- No package manager (`apt`, `apk`)
+- No utilities (`curl`, `wget`, `ls`)
+- No dynamic linker (`/lib/ld-linux.so`)
+
+The `nonroot` tag sets UID/GID to 65532 (non-root user).
+
+**Why it matters for CVEs:** With almost no software present, the attack surface shrinks to near zero. There's no shell for shell injection, no package manager to exploit, no utilities for reconnaissance. Even if an attacker compromises the application, they can't escalate privileges or move laterally because there's nothing else in the container to exploit.
+
+**d) `-ldflags='-s -w'` and `-trimpath`: what does each flag do, and what's the cost?**
+
+- `-s`: strips the symbol table (removes function names from binary)
+- `-w`: strips DWARF debugging information (removes debug symbols)
+- `-trimpath`: removes local filesystem paths from the compiled binary, improving reproducibility
+
+**Cost:** Loss of debuggability. Stack traces lose file paths and line numbers, making post-mortem debugging harder. Binary size drops ~20-30%.
+
+For production containers, this trade-off is acceptable — you debug with logs and metrics, not by attaching a debugger to the binary.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+### `compose.yaml`
+
+```yaml
+services:
+  # One-shot init: fixes ownership of the named volume so the nonroot app
+  # (UID 65532) can write to /data. Runs to completion before quicknotes starts.
+  init-data:
+    image: busybox:1.36
+    command: ["sh", "-c", "chown -R 65532:65532 /data"]
+    volumes:
+      - quicknotes-data:/data
+    restart: "no"
+
+  quicknotes:
+    build: ./app
+    image: quicknotes:lab6
+    depends_on:
+      init-data:
+        condition: service_completed_successfully
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/app/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/quicknotes", "-healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:
+```
+
+### Persistence Test Output
+
+**Step 1: Check health (seed loaded)**
+```bash
+$ curl -s http://localhost:8080/health
+{"notes":4,"status":"ok"}
+```
+
+**Step 2: Create note**
+```bash
+$ curl -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"durable","body":"survive a restart"}' \
+  http://localhost:8080/notes
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T12:35:15.272673189Z"}
+```
+
+**Step 3: Verify note exists**
+```bash
+$ curl -s http://localhost:8080/notes | grep durable
+[{"id":1,"title":"Welcome to QuickNotes",...},{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T12:35:15.272673189Z"}]
+```
+
+**Step 4: `docker compose down` (no `-v`)**
+```bash
+$ docker compose down
+[+] down 3/3
+ ✔ Container devops-intro-quicknotes-1 Removed
+ ✔ Container devops-intro-init-data-1  Removed
+ ✔ Network devops-intro_default        Removed
+```
+
+**Step 5: `docker compose up -d`**
+```bash
+$ docker compose up -d
+[+] up 3/3
+ ✔ Network devops-intro_default        Created
+ ✔ Container devops-intro-init-data-1  Exited
+ ✔ Container devops-intro-quicknotes-1 Started
+```
+
+**Step 6: Note STILL exists**
+```bash
+$ curl -s http://localhost:8080/notes | grep durable
+[{"id":4,"title":"Endpoint cheat-sheet",...},{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T12:35:15.272673189Z"},...]
+```
+
+**Step 7: `docker compose down -v` (volume destroyed)**
+```bash
+$ docker compose down -v
+[+] down 4/4
+ ✔ Container devops-intro-quicknotes-1 Removed
+ ✔ Container devops-intro-init-data-1  Removed
+ ✔ Volume devops-intro_quicknotes-data Removed
+ ✔ Network devops-intro_default        Removed
+```
+
+**Step 8: `docker compose up -d`**
+```bash
+$ docker compose up -d
+[+] up 4/4
+ ✔ Network devops-intro_default        Created
+ ✔ Volume devops-intro_quicknotes-data Created
+ ✔ Container devops-intro-init-data-1  Exited
+ ✔ Container devops-intro-quicknotes-1 Started
+```
+
+**Step 9: Note is GONE**
+```bash
+$ curl -s http://localhost:8080/notes | grep durable
+# (no output - only seed notes remain)
+```
+
+### Design Questions
+
+**e) Distroless has no shell. How do you healthcheck it?**
+
+Strategy: modification of `main.go` (added `-healthcheck` flag to enable self-probing) - use a binary already present in the image.
+
+Since QuickNotes is the only binary in the distroless image, the healthcheck invokes it directly with a healthcheck flag (`["CMD", "/quicknotes", "-healthcheck"]`). The binary performs an HTTP request to its own `/health` endpoint and exits 0/1.
+
+
+Alternative strategies:
+- **Sidecar container**: Run a separate container with `curl`/`wget` to check health — adds complexity
+- **Debug image variant**: Use `gcr.io/distroless/static:debug-nonroot` which includes a shell and busybox tools — breaks the security model
+- **Process check only**: Rely on Docker's default behavior of checking if the process is alive — doesn't verify the service is actually healthy
+
+The chosen strategy (invoke the binary itself) is the cleanest: no extra containers, no shell, no additional attack surface.
+
+
+
+**f) Why does `volumes: [quicknotes-data:/data]` survive `docker compose down`?**
+
+Named volumes are Docker-managed resources, independent of containers. `docker compose down` removes containers and networks but intentionally preserves volumes — data is assumed valuable and should persist by default.
+
+Only `docker compose down -v` explicitly destroys volumes. This design prevents accidental data loss. If you want to destroy the data, you must explicitly opt-in with `-v`.
+
+**g) `depends_on` without `condition: service_healthy` — what does it actually wait for?**
+
+Without `condition: service_healthy`, `depends_on` only waits for the container to **start**, not for the service inside to be **ready**.
+
+**Bug scenario:** If `quicknotes` depends on `redis`, quicknotes may start before redis accepts connections, causing `connection refused` errors on startup. The container is "up" (process running) but the service isn't healthy (not accepting connections yet).
+
+Using `condition: service_healthy` makes Compose wait for the healthcheck to pass before starting dependent services, ensuring the service is actually ready to accept connections.
+
+In our case, we use `depends_on` with `condition: service_completed_successfully` for the init-data container, ensuring the volume has correct permissions before quicknotes starts.

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -265,3 +265,122 @@ Without `condition: service_healthy`, `depends_on` only waits for the container 
 Using `condition: service_healthy` makes Compose wait for the healthcheck to pass before starting dependent services, ensuring the service is actually ready to accept connections.
 
 In our case, we use `depends_on` with `condition: service_completed_successfully` for the init-data container, ensuring the volume has correct permissions before quicknotes starts.
+
+
+## Bonus Task — The 6 Security Defaults
+
+### Hardened `compose.yaml` snippet
+
+```yaml
+services:
+  init-data:
+    image: busybox:1.36
+    command: ["sh", "-c", "chown -R 65532:65532 /data"]
+    volumes:
+      - quicknotes-data:/data
+    restart: "no"
+
+  quicknotes:
+    build: ./app
+    image: quicknotes:lab6
+    depends_on:
+      init-data:
+        condition: service_completed_successfully
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/app/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "/quicknotes", "-healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    #Security hardening (Bonus)
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+volumes:
+  quicknotes-data:
+```
+
+### Verification Outputs
+
+**1. USER nonroot**
+```bash
+$ docker inspect quicknotes:lab6 --format '{{ .Config.User }}'
+nonroot:nonroot
+```
+
+**2. No shell available**
+```bash
+$ docker compose exec quicknotes sh
+OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH
+```
+
+**3. Capabilities dropped**
+```bash
+$ docker inspect devops-intro-quicknotes-1 --format '{{ .HostConfig.CapDrop }}'
+[ALL]
+```
+
+**4. Read-only root filesystem**
+```bash
+$ docker compose exec quicknotes touch /etc/test
+OCI runtime exec failed: exec failed: unable to start container process: exec: "touch": executable file not found in $PATH
+```
+No shell to execute commands. Even with a debug image, writes to `/etc` would fail with `Read-only file system` because `read_only: true` is set.
+
+**5. no-new-privileges**
+```bash
+$ docker inspect devops-intro-quicknotes-1 --format '{{ .HostConfig.SecurityOpt }}'
+[no-new-privileges:true]
+```
+
+**6. Distroless base (verified in Task 1)**
+```bash
+$ docker compose exec quicknotes ls /bin
+OCI runtime exec failed: exec failed: unable to start container process: exec: "ls": executable file not found in $PATH
+```
+No utilities available — only the application binary exists.
+
+### Trivy Scan
+
+```bash
+$ docker run --rm -v //var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:0.59.1 image --severity HIGH,CRITICAL --no-progress \
+  quicknotes:lab6
+
+quicknotes:lab6 (debian 13.5)
+=============================
+Total: 0 (HIGH: 0, CRITICAL: 0)
+
+quicknotes (gobinary)
+=====================
+Total: 13 (HIGH: 13, CRITICAL: 0)
+```
+
+**Analysis:**
+- **OS layer (distroless debian 13.5):** 0 HIGH, 0 CRITICAL — minimal base image with no vulnerabilities
+- **Go binary (stdlib v1.24.13):** 13 HIGH — CVEs in Go standard library released after Go 1.24.13 (e.g., CVE-2026-25679, CVE-2026-27145). 
+These are not Dockerfile issues; they're fixed by upgrading Go to 1.25.8+ or 1.26.1+
+
+**Key insight:** Distroless achieves its goal — the OS layer is clean. The remaining vulnerabilities are in the application's compiled dependencies (Go stdlib), which is a separate concern addressed by updating the builder image version (`golang:1.25-alpine` or later).
+This demonstrates why scanning in CI is essential: catch dependency drift before it reaches production.
+
+### Which default gives the most security per line of YAML?
+
+The distroless base image provides the most security per line of YAML.
+A single `FROM gcr.io/distroless/static:nonroot` line eliminates the shell, package manager, and all unnecessary utilities — removing entire attack classes (shell injection, privilege escalation via package exploits, reconnaissance tools).
+It reduces the CVE surface area by ~95% compared to a standard base image, with zero configuration cost beyond choosing the right base. 
+Combined with `USER nonroot`, it ensures that even if an attacker compromises the application, they cannot escalate privileges or execute arbitrary commands because there's no shell and no utilities to exploit.


### PR DESCRIPTION
## Goal
Write a multi-stage Dockerfile producing a 15.5 MB distroless image of QuickNotes and a compose.yaml with healthcheck + persistent volume, plus the 6 security hardening defaults.

## Changes
- `app/Dockerfile` — multi-stage build (`golang:1.24-alpine` -> `gcr.io/distroless/static:nonroot`), static binary with `CGO_ENABLED=0`, stripped with `-ldflags='-s -w' -trimpath`, final image 15.5 MB (≤ 25 MB)
- `compose.yaml` — `quicknotes` service with healthcheck via self-probing binary (`/quicknotes -healthcheck`), named volume `quicknotes-data:/data`, `init-data` sidecar for volume ownership, env vars (`ADDR`, `DATA_PATH`, `SEED_PATH`), `restart: unless-stopped`
- `submissions/lab6.md` — design questions a–g answered, persistence test output (note survives `down && up`, disappears after `down -v`), Trivy scan summary
- Bonus: 6 security defaults applied — `USER nonroot:nonroot`, distroless base, `cap_drop: [ALL]`, `read_only: true` + `tmpfs: [/tmp]`, `security_opt: [no-new-privileges:true]`, Trivy scan (0 HIGH/CRITICAL in OS layer)

## Testing
- `docker build -t quicknotes:lab6 .` -> image size 15.5 MB (≤ 25 MB)
- `docker compose up --build -d` -> status `(healthy)`, logs show `notes loaded: 4`
- Persistence test: POSTed note survives `docker compose down && up`, disappears after `docker compose down -v`
- `docker compose exec quicknotes sh` -> fails with `executable file not found in $PATH` (no shell in distroless)
- `docker inspect quicknotes:lab6 --format '{{ .Config.User }}'` -> `nonroot:nonroot`
- `docker inspect <container> --format '{{ .HostConfig.CapDrop }}'` -> `[ALL]`
- `docker inspect <container> --format '{{ .HostConfig.SecurityOpt }}'` -> `[no-new-privileges:true]`
- Trivy scan: `quicknotes:lab6 (debian 13.5)` -> `Total: 0 (HIGH: 0, CRITICAL: 0)` in OS layer; 13 HIGH in Go stdlib (fixed by upgrading builder to `golang:1.25+`)

## Checklist
- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/lab6.md` updated