### PR TITLE
docs(lab6): dockerize QuickNotes with compose

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (<= 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: quicknotes-ci
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - app/**
+      - .github/workflows/ci.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - app/**
+      - .github/workflows/ci.yml
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: app
+
+jobs:
+  vet:
+    name: vet (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.23"
+          - "1.24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Run go vet
+        run: go vet ./...
+
+  test:
+    name: test (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.23"
+          - "1.24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Run tests with race detector
+        run: go test -race -count=1 ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.24"
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+      - name: Run golangci-lint
+        run: golangci-lint run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Run go vet
         run: go vet ./...
 
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Run tests with race detector
         run: go test -race -count=1 ./...
 
@@ -75,7 +75,7 @@ jobs:
         with:
           go-version: "1.24"
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
       - name: Run golangci-lint

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod ./
+COPY go.sum* ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -trimpath \
+    -ldflags='-s -w' \
+    -o /out/quicknotes .
+
+RUN mkdir -p /tmp/healthcheck && \
+    printf '%s\n' \
+      'package main' \
+      '' \
+      'import (' \
+      '	"net/http"' \
+      '	"os"' \
+      ')' \
+      '' \
+      'func main() {' \
+      '	resp, err := http.Get("http://127.0.0.1:8080/health")' \
+      '	if err != nil || resp.StatusCode != http.StatusOK {' \
+      '		os.Exit(1)' \
+      '	}' \
+      '}' \
+      > /tmp/healthcheck/main.go && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+      -trimpath \
+      -ldflags='-s -w' \
+      -o /out/healthcheck /tmp/healthcheck/main.go
+
+RUN mkdir -p /empty-data && chown 65532:65532 /empty-data
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /out/quicknotes /quicknotes
+COPY --from=builder /out/healthcheck /healthcheck
+COPY seed.json /seed.json
+COPY --from=builder --chown=65532:65532 /empty-data /data
+
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/quicknotes"]
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/healthcheck"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: "0.0.0.0:8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,205 @@
+# Lab 6 Submission
+
+Host used for the run: Ubuntu 24.04.3 LTS x86_64 cloud server with Docker 29.4.2 and Compose v5.1.3.
+
+## Task 1 - Multi-Stage Dockerfile
+
+`app/Dockerfile` is committed in the repository. Key points:
+
+- Builder: `golang:1.24-alpine`
+- Runtime: `gcr.io/distroless/static-debian12:nonroot`
+- Static build with `CGO_ENABLED=0`, `-trimpath`, `-ldflags='-s -w'`
+- `USER nonroot:nonroot`, `EXPOSE 8080`, exec-form `ENTRYPOINT`
+- `go.mod` copied before source for layer caching
+- A tiny static `/healthcheck` binary is built in the builder stage for HTTP probes
+- `/data` is seeded in the image with UID 65532 so named volumes inherit writable ownership
+
+Build and image size:
+
+```text
+$ docker build -t quicknotes:lab6 ./app
+...
+$ docker images quicknotes:lab6
+IMAGE             ID             DISK USAGE   CONTENT SIZE   EXTRA
+quicknotes:lab6   f63a1637227a       22.5MB          5.6MB
+
+$ docker images golang:1.24-alpine
+IMAGE                ID             DISK USAGE   CONTENT SIZE   EXTRA
+golang:1.24-alpine   8bee1901f1e5        395MB         83.5MB
+```
+
+`docker inspect` excerpt:
+
+```text
+User=nonroot:nonroot
+ExposedPorts={"8080/tcp":{}}
+Entrypoint=["/quicknotes"]
+Healthcheck={"Test":["CMD","/healthcheck"],"Interval":10000000000,"Timeout":3000000000,"StartPeriod":5000000000,"Retries":3}
+```
+
+Runtime verification:
+
+```text
+$ docker run -d --name qn-lab6-run -p 18081:8080 \
+  -e ADDR=0.0.0.0:8080 -e DATA_PATH=/data/notes.json -e SEED_PATH=/seed.json \
+  -v qn-lab6-run-data:/data quicknotes:lab6
+$ curl -s http://127.0.0.1:18081/health
+{"notes":4,"status":"ok"}
+```
+
+### Layer-cache comparison
+
+Bad order (`COPY . .` before `go mod download`), rebuild after touching one source file:
+
+```text
+#10 [builder 4/5] RUN go mod download
+#12 [builder 5/5] RUN CGO_ENABLED=0 ... go build ...
+real 0.72
+```
+
+Good order (`COPY go.mod` + `go mod download` before `COPY . .`), rebuild after the same change:
+
+```text
+#20 [builder 5/9] RUN go mod download
+#20 CACHED
+#17 [builder 7/9] RUN CGO_ENABLED=0 ... go build ...
+real 1.30
+```
+
+The bad Dockerfile invalidates dependency download on every source edit. The good Dockerfile keeps `go mod download` cached and only rebuilds the binary layer.
+
+### Design answers
+
+a) Layer order matters because Docker caches each instruction. Putting `COPY . .` before `go mod download` ties the dependency layer to every source change, so `go mod download` reruns even when `go.mod` is unchanged. Copying `go.mod` first keeps dependency download cached across normal code edits.
+
+b) `CGO_ENABLED=0` produces a fully static binary with no libc dependency. Distroless static has no dynamic linker; a CGO-enabled binary fails at startup with errors like `no such file or directory` when the loader is missing.
+
+c) `gcr.io/distroless/static:nonroot` is a minimal runtime image with just the app, CA certs, `/etc/passwd`, and timezone data. It has no shell, package manager, or extra utilities. Fewer packages means a much smaller attack surface and fewer OS-level CVEs to patch.
+
+d) `-s -w` strips the symbol table and DWARF debug info to shrink the binary. `-trimpath` removes local filesystem paths from the binary for reproducible builds. The cost is harder post-mortem debugging from the stripped binary alone.
+
+## Task 2 - Compose + Healthcheck + Persistent Volume
+
+Root `compose.yaml`:
+
+```yaml
+services:
+  quicknotes:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: "0.0.0.0:8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:
+```
+
+Persistence test:
+
+```text
+$ docker compose up --build -d
+$ curl -s http://127.0.0.1:8080/health
+{"notes":4,"status":"ok"}
+
+$ curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"durable","body":"survive a restart"}' \
+  http://127.0.0.1:8080/notes
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T20:27:39.237347063Z"}
+
+--- after POST ---
+$ curl -s http://127.0.0.1:8080/notes | grep durable
+..."title":"durable"...
+
+$ docker compose down
+$ docker compose up -d
+
+--- after down/up ---
+$ curl -s http://127.0.0.1:8080/notes | grep durable
+..."title":"durable"...
+
+$ docker compose down -v
+$ docker compose up -d
+
+--- after down -v ---
+durable gone (expected)
+```
+
+Compose status after startup:
+
+```text
+NAME                       IMAGE             STATUS                    PORTS
+devops-lab6-quicknotes-1   quicknotes:lab6   Up 12 seconds (healthy)   0.0.0.0:8080->8080/tcp
+```
+
+### Design answers
+
+e) Distroless has no shell, so a shell-form healthcheck cannot work. I built a tiny static `/healthcheck` binary in the builder stage and use exec-form `CMD ["/healthcheck"]` to call `http://127.0.0.1:8080/health`. That gives a real HTTP probe without adding a shell to the runtime image.
+
+f) `volumes: [quicknotes-data:/data]` survives `docker compose down` because Compose removes containers and networks, not named volumes. The data stays in Docker's volume store until `docker compose down -v`, `docker volume rm`, or `docker volume prune`.
+
+g) `depends_on` without `condition: service_healthy` only waits for the dependency container to start, not for the app inside it to be ready. A dependent service can send traffic before QuickNotes is listening and see connection errors.
+
+## Bonus - 6 Security Defaults
+
+Hardened `services.quicknotes` block is shown above (`cap_drop`, `read_only`, `tmpfs`, `security_opt`, nonroot image, distroless base).
+
+Verification:
+
+```text
+$ docker inspect quicknotes:lab6 --format '{{ .Config.User }}'
+nonroot:nonroot
+
+$ docker compose exec quicknotes sh
+OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH
+
+$ docker inspect <container> --format '{{ .HostConfig.CapDrop }}'
+[ALL]
+
+$ docker inspect <container> --format '{{ .HostConfig.ReadonlyRootfs }}'
+true
+
+$ docker inspect <container> --format '{{ .HostConfig.SecurityOpt }}'
+[no-new-privileges:true]
+
+$ docker inspect <container> --format '{{json .State.Health.Status}}'
+"healthy"
+```
+
+Read-only root was also confirmed via `ReadonlyRootfs=true`; there is no shell in the runtime image to run `touch /etc/test` inside the container itself.
+
+Trivy scan:
+
+```text
+$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:0.59.1 image --severity HIGH,CRITICAL --no-progress \
+  quicknotes:lab6
+
+quicknotes:lab6 (debian 12.14)
+Total: 0 (HIGH: 0, CRITICAL: 0)
+```
+
+Trivy also reported Go stdlib findings inside the compiled binaries; the distroless OS layer itself had zero HIGH/CRITICAL findings.
+
+The best security-per-line default here is `cap_drop: [ALL]`. It removes Linux capabilities from the container process namespace with one YAML line and directly reduces kernel-level escape options. Distroless and nonroot matter a lot too, but capability dropping is the clearest enforcement knob in Compose.


### PR DESCRIPTION
## Goal
Submit Lab 6 requirements.

## Changes
- Added multi-stage `app/Dockerfile` with distroless nonroot runtime (22.5 MB image)
- Added root `compose.yaml` with named volume, HTTP healthcheck, and hardening defaults
- Documented build evidence, persistence test, security verification, and Trivy scan in `submissions/lab6.md`

## Testing
- Built `quicknotes:lab6` and verified `/health` from host port 8080
- Confirmed POSTed note survives `docker compose down && up`
- Confirmed note is removed after `docker compose down -v`
- Verified nonroot user, dropped capabilities, read-only root, and no-new-privileges
- Ran Trivy 0.59.1 scan on the final image

## Checklist
- [x] Title is a clear sentence (<= 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/labN.md` updated