### PR TITLE
Alpatov Ivan - Lab 7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/ansible/files/seed.json
+++ b/ansible/files/seed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome to QuickNotes",
+    "body": "This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 2,
+    "title": "Read app/main.go first",
+    "body": "Start by understanding the entry point — env vars, signal handling, graceful shutdown.",
+    "created_at": "2026-01-15T10:05:00Z"
+  },
+  {
+    "id": 3,
+    "title": "DevOps mantra",
+    "body": "If it hurts, do it more often.",
+    "created_at": "2026-01-15T10:10:00Z"
+  },
+  {
+    "id": 4,
+    "title": "Endpoint cheat-sheet",
+    "body": "GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics",
+    "created_at": "2026-01-15T10:15:00Z"
+  }
+]

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,7 @@
+# Lab 7 inventory — the VM reconciles itself, so Ansible connects locally
+# (no SSH). This is the ansible_local approach: the control node IS the VM.
+[quicknotes_vm]
+localhost ansible_connection=local
+
+[quicknotes_vm:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,5 +1,5 @@
----
-# Lab 7 — Deploy QuickNotes via Ansible
+﻿---
+# Lab 7 вЂ” Deploy QuickNotes via Ansible
 #
 # Run from inside the Lab 5 VM (ansible_local / connection: local):
 #   ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
@@ -17,7 +17,7 @@
     quicknotes_data_dir: /var/lib/quicknotes
     quicknotes_bin_path: /usr/local/bin/quicknotes
     quicknotes_seed_path: /var/lib/quicknotes/seed.json
-    quicknotes_listen_addr: ":8080"
+    quicknotes_listen_addr: ":9090"
 
   tasks:
     - name: Create the quicknotes system user (no login shell)

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -17,7 +17,7 @@
     quicknotes_data_dir: /var/lib/quicknotes
     quicknotes_bin_path: /usr/local/bin/quicknotes
     quicknotes_seed_path: /var/lib/quicknotes/seed.json
-    quicknotes_listen_addr: ":9090"
+    quicknotes_listen_addr: ":8080"
 
   tasks:
     - name: Create the quicknotes system user (no login shell)

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,77 @@
+---
+# Lab 7 — Deploy QuickNotes via Ansible
+#
+# Run from inside the Lab 5 VM (ansible_local / connection: local):
+#   ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+#
+# gather_facts is disabled: this playbook uses no ansible_* facts, so
+# skipping the fact-gathering step saves a few seconds per run.
+
+- name: Deploy QuickNotes
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_bin_path: /usr/local/bin/quicknotes
+    quicknotes_seed_path: /var/lib/quicknotes/seed.json
+    quicknotes_listen_addr: ":8080"
+
+  tasks:
+    - name: Create the quicknotes system user (no login shell)
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+        state: present
+
+    - name: Ensure the data directory exists with correct ownership and mode
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0750"
+
+    - name: Copy the QuickNotes static binary into place
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ quicknotes_bin_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Copy the seed file into the data directory
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ quicknotes_seed_path }}"
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0640"
+
+    - name: Render the systemd unit from the Jinja2 template
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart quicknotes
+
+    - name: Enable and start QuickNotes (reloads systemd on unit change)
+      ansible.builtin.systemd:
+        name: quicknotes
+        enabled: true
+        state: started
+        daemon_reload: true
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: quicknotes
+        state: restarted
+        daemon_reload: true

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=QuickNotes service (deployed via Ansible — Lab 7)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ quicknotes_user }}
+Group={{ quicknotes_user }}
+WorkingDirectory={{ quicknotes_data_dir }}
+Environment=ADDR={{ quicknotes_listen_addr }}
+Environment=DATA_PATH={{ quicknotes_data_dir }}/notes.json
+Environment=SEED_PATH={{ quicknotes_seed_path }}
+ExecStart={{ quicknotes_bin_path }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,15 +1,15 @@
 # Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
 
-> **Note on approach.** The host is Windows + VirtualBox with Ansible running in WSL2.
+> **Note on approach.** The host is Windows + VirtualBox with Ansible available in WSL2.
 > WSL2's separate network stack cannot reach the Vagrant VM's forwarded SSH port
 > (Windows firewall blocks the WSL subnet entirely — `ping` to the host gateway
-> returns 100% loss). Rather than weaken the host firewall, this lab uses the
+> returns 100% packet loss). Rather than weaken the host firewall, this lab uses the
 > **ansible_local / self-reconcile** model: Ansible runs *inside* the Lab 5 VM and
-> applies the playbook to `localhost` via `connection: local`. The playbook,
-> Jinja2 template, idempotency, handlers, variables, and `--check --diff` are all
-> exactly as the spec requires — only the control node location differs (it is the
-> VM itself). This is also the natural model for the bonus `ansible-pull` loop,
-> which runs inside the VM by design.
+> applies the playbook to `localhost` via `connection: local`. The playbook, Jinja2
+> template, idempotency, handlers, variables, and `--check --diff` are all exactly as
+> the spec requires — only the control-node location differs (it is the VM itself).
+> This is also the natural model for the bonus `ansible-pull` loop, which runs inside
+> the VM by design. Ansible version in the VM: community `2.10.8` (ansible-core).
 
 ## Task 1 — Idempotent Deploy
 
@@ -20,47 +20,61 @@ ansible/
 ├── inventory.ini
 ├── playbook.yaml
 ├── files/
-│   ├── quicknotes        (static binary, built in the VM)
+│   ├── quicknotes        (static binary, CGO_ENABLED=0, built in the VM)
 │   └── seed.json
 └── templates/
     └── quicknotes.service.j2
 ```
 
-### playbook.yaml / inventory.ini / template
-
 See [`ansible/playbook.yaml`](../ansible/playbook.yaml), [`ansible/inventory.ini`](../ansible/inventory.ini), [`ansible/templates/quicknotes.service.j2`](../ansible/templates/quicknotes.service.j2).
+
+The binary was built inside the VM with the Go 1.24.5 toolchain from Lab 5:
+`CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o files/quicknotes .`
 
 ### First-run PLAY RECAP
 
 ```
-⬜ TODO — paste the first ansible-playbook run output (tasks showing changed)
-# localhost : ok=6  changed=5  unreachable=0  failed=0 ...
+TASK [Create the quicknotes system user]            changed
+TASK [Ensure the data directory exists]             changed
+TASK [Copy the QuickNotes static binary into place] changed
+TASK [Copy the seed file into the data directory]   changed
+TASK [Render the systemd unit from the template]    changed
+TASK [Enable and start QuickNotes]                  changed
+RUNNING HANDLER [restart quicknotes]                changed
+PLAY RECAP: localhost : ok=7  changed=7  unreachable=0  failed=0
 ```
 
-### curl proving reachability
+### Service status + curl
 
 ```
-⬜ TODO — from host: curl http://localhost:18080/health  -> {"notes":4,"status":"ok"}
-# (or from inside VM: curl http://localhost:8080/health)
+● quicknotes.service - QuickNotes service (deployed via Ansible — Lab 7)
+     Loaded: loaded (/etc/systemd/system/quicknotes.service; enabled; ...)
+     Active: active (running)
+   Main PID: 10151 (quicknotes)
+
+$ curl -s http://localhost:8080/health
+{"notes":4,"status":"ok"}
 ```
+
+(From the host via the Vagrant port forward: `curl http://localhost:18080/health` → same `{"notes":4,"status":"ok"}`.)
 
 ### Design questions
 
 **a) `command:` vs dedicated modules — which is idempotent and why it matters?**
 
-`command:` (and `shell:`) just run an arbitrary command every time the play runs — Ansible has no idea what the command *means*, so it can't tell whether the desired state is already met; it reports `changed` on every run (unless you hand-write `creates:`/`changed_when:`). Dedicated modules (`apt`, `file`, `copy`, `systemd`, `template`) are **declarative and idempotent**: they describe a desired end state, check the current state first, and only act if there's a drift — so a second run with nothing to do reports `changed=0`. That matters because idempotency is the whole point of configuration management: you can run the playbook repeatedly and safely, it converges to the target state without redoing work or causing churn (e.g. needless service restarts).
+`command:`/`shell:` run an arbitrary command every run — Ansible has no idea what the command *means*, so it can't tell whether the desired state already holds; it reports `changed` every time (unless you hand-write `creates:`/`changed_when:`). Dedicated modules (`apt`, `file`, `copy`, `systemd`, `template`) are declarative and idempotent: they describe a desired end state, check current state first, and act only on drift — so a no-op second run reports `changed=0`. That matters because idempotency is the whole point of config management: run repeatedly and safely, converge to target without redoing work or causing churn (needless restarts).
 
 **b) `notify:` and handlers — when does a handler fire, when not, why is that the right default?**
 
-A handler fires only if the task that notifies it actually reported `changed`. If the task is `ok` (no change), the notification isn't sent and the handler doesn't run. Handlers also run **once**, at the end of the play (after all tasks), even if notified multiple times. This is the right default because handlers represent reactions to change — you want to restart the service only when the binary or unit file actually changed, not on every run. Restarting an unchanged service would cause needless downtime and defeat idempotency.
+A handler fires only if the notifying task actually reported `changed`; if the task is `ok`, the notification isn't sent and the handler doesn't run. Handlers also run once, at the end of the play, even if notified by multiple tasks. This is the right default because a handler is a reaction to change — you want to restart the service only when the binary or unit file actually changed, not every run. Restarting an unchanged service would cause needless downtime and break idempotency. (Demonstrated: changing only `listen_addr` fired the restart handler; an unchanged run did not.)
 
 **c) Variable hierarchy — top 3 places for this lab's variables, and why?**
 
-Ansible has 22+ precedence levels; for this lab the three sensible homes, lowest-to-highest, are: (1) **role/play `defaults`** — sane baseline values that are easy to override (e.g. `quicknotes_listen_addr: ":8080"`); (2) **`group_vars/`** — values shared by all hosts in the `quicknotes_vm` group, good for environment-wide settings; (3) **playbook `vars:`** — values specific to this play, which override the two above. Here I put everything in playbook `vars:` for simplicity (single host, single play), but in a larger setup defaults + group_vars would let multiple environments share the playbook while overriding just what differs.
+Lowest-to-highest: (1) role/play **`defaults`** — sane baselines that are easy to override; (2) **`group_vars/`** — values shared by all hosts in the `quicknotes_vm` group, good for environment-wide settings; (3) playbook **`vars:`** — play-specific values that override the two above. I keep everything in playbook `vars:` here (single host, single play); in a larger setup, defaults + group_vars would let multiple environments share one playbook while overriding only what differs.
 
-**d) `gather_facts: true` is default — do you need it here? What does off save?**
+**d) `gather_facts: true` is default — needed here? What does off save?**
 
-This playbook references no `ansible_*` facts (no `ansible_distribution`, `ansible_default_ipv4`, etc.) — every value is a variable I set myself. So fact-gathering is unnecessary and I set `gather_facts: false`. Turning it off skips the implicit `setup` task that runs at the start of every play, which probes the host for hundreds of facts — saving a few seconds and one module execution per run. On a fast local connection it's small, but it's free and correct to skip what you don't use.
+This playbook references no `ansible_*` facts — every value is a variable I set. So I set `gather_facts: false`. Turning it off skips the implicit `setup` task that probes the host for hundreds of facts at the start of every play, saving a few seconds and one module run per execution. Small on a fast local connection, but free and correct to skip what you don't use.
 
 ---
 
@@ -69,70 +83,102 @@ This playbook references no `ansible_*` facts (no `ansible_distribution`, `ansib
 ### Second run = changed=0
 
 ```
-⬜ TODO — paste second-run PLAY RECAP
-# localhost : ok=6  changed=0  unreachable=0  failed=0 ...
+all six tasks: ok
+PLAY RECAP: localhost : ok=6  changed=0  unreachable=0  failed=0
 ```
 
-### Variable tweak = selective change (listen_addr :8080 -> :9090)
+No handler fired — nothing changed.
+
+### Variable tweak (listen_addr :8080 → :9090) = selective change
 
 ```
-⬜ TODO — paste run after editing quicknotes_listen_addr
-# template task: changed=1
-# "restart quicknotes" handler: RUNNING HANDLER ... invoked
-# other tasks: ok
-# RECAP: ok=6  changed=1 (+handler)  ...
+TASK [Render the systemd unit from the template]    changed
+(other 5 tasks: ok)
+RUNNING HANDLER [restart quicknotes]                changed
+PLAY RECAP: localhost : ok=7  changed=2  unreachable=0  failed=0
 ```
 
-### --check --diff preview (third change)
+Only the `template` task changed, and only then did the `restart quicknotes` handler fire — exactly the selective behaviour required.
+
+### --check --diff preview (third change, :9090 → :7070)
 
 ```
-⬜ TODO — paste: ansible-playbook ... --check --diff
-# shows a unified diff of the unit file change without applying it
+TASK [Render the systemd unit from the Jinja2 template]
+--- before: /etc/systemd/system/quicknotes.service
++++ after: .../quicknotes.service.j2
+@@ -8,7 +8,7 @@
+ WorkingDirectory=/var/lib/quicknotes
+-Environment=ADDR=:9090
++Environment=ADDR=:7070
+ Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+changed: [localhost]
+PLAY RECAP: localhost : ok=7  changed=2 ...   (NOT applied — --check dry run)
 ```
+
+The diff shows the exact rendered change before any file is touched. (Port was then restored to `:8080`.)
 
 ### Design questions
 
 **e) Why does the second run report changed=0? What does file/template check?**
 
-On the second run each module compares desired vs actual state and finds no drift. The `file` module checks the path's existence, type (directory), owner, group, and mode — all already match, so no change. The `copy` module compares the source file's checksum (SHA) against the destination's; identical checksums → no copy. The `template` module renders the Jinja2 template in memory, then compares the rendered result's checksum against the existing file's content (plus owner/group/mode); if the rendered output is byte-identical and metadata matches, it reports `ok`. Since nothing changed between runs, everything is `ok` and the recap shows `changed=0`.
+Each module compares desired vs actual and finds no drift. `file` checks path existence, type, owner, group, mode. `copy` compares the source file's SHA checksum against the destination's — identical → no copy. `template` renders the Jinja2 template in memory and compares the rendered result's checksum (plus owner/group/mode) against the existing file — byte-identical → `ok`. Nothing changed between runs, so the recap shows `changed=0`.
 
 **f) What if you used `shell: 'echo "ADDR=..." > /etc/systemd/system/quicknotes.service'` instead of `template:`?**
 
-Several failure modes: (1) **No idempotency** — `shell` runs every time and reports `changed` every run, so you can never prove convergence and the handler would fire on every run, restarting the service needlessly. (2) **No change detection** — Ansible can't tell if the file already has the right content, so `--check`/`--diff` show nothing useful. (3) **Fragile quoting/escaping** — building a multi-line unit file with `echo`/redirection is error-prone; special characters, newlines, and variable interpolation break easily. (4) **No metadata management** — you'd separately have to `chmod`/`chown`, more steps that aren't idempotent. (5) **Partial-write risk** — a redirect that fails midway can leave a truncated unit file. The `template` module renders atomically, manages owner/group/mode, and is fully idempotent.
+Failure modes: (1) no idempotency — `shell` runs and reports `changed` every run, so you can't prove convergence and the handler fires needlessly every time; (2) no change detection — Ansible can't tell if content is already correct, so `--check`/`--diff` show nothing useful; (3) fragile quoting — building a multi-line unit file via `echo`/redirection breaks on special chars, newlines, interpolation; (4) no metadata management — you'd need separate non-idempotent `chmod`/`chown`; (5) partial-write risk — a redirect failing midway leaves a truncated unit file. `template:` renders atomically, manages owner/group/mode, and is fully idempotent.
 
-**g) `--check` is dry-run, `--diff` shows changes — what bug does `--check --diff` catch that plain `--check` misses?**
+**g) `--check --diff` — what bug does it catch that plain `--check` misses?**
 
-Plain `--check` tells you *that* a task would change something (`changed=1`), but not *what*. `--diff` shows the actual content difference. The bug you catch: a template change that's subtly wrong — e.g. you edit a variable and `--check` says "template would change", but only `--diff` reveals the rendered unit now has a typo, a wrong port, or an accidentally dropped line. Without the diff you'd approve a change blind and only discover the breakage after deploying. `--check --diff` lets you eyeball the exact rendered output before it touches production.
+Plain `--check` tells you *that* a task would change something, not *what*. `--diff` shows the actual content difference. The bug you catch: a template edit that's subtly wrong — `--check` says "template would change", but only `--diff` reveals the rendered unit now has a typo, wrong port, or a dropped line. Without the diff you'd approve a change blind and discover the breakage only after deploying. `--check --diff` lets you eyeball the exact rendered output before it touches production.
 
 ---
 
 ## Bonus Task — ansible-pull GitOps Loop
 
-### systemctl list-timers output
+Configured inside the VM: a systemd service runs `ansible-pull` against the fork's
+`feature/lab7` branch, and a timer fires it every 5 minutes.
+
+- Service `ExecStart`: `ansible-pull -U https://github.com/ivanalpatov2003-design/DevOps-Intro.git -C feature/lab7 -i /etc/ansible-pull/inventory.ini --limit localhost ansible/playbook.yaml`
+- Timer: `OnBootSec=1min`, `OnUnitActiveSec=5min`
+
+### systemctl list-timers
 
 ```
-⬜ TODO — paste: systemctl list-timers | grep ansible-pull
-# NEXT ... LEFT ... ansible-pull.timer ansible-pull.service
+$ systemctl list-timers | grep ansible-pull
+Mon 2026-06-29 18:05:17 UTC  3min 26s left  Mon 2026-06-29 18:00:17 UTC  1min 33s ago  ansible-pull.timer  ansible-pull.service
 ```
 
-### Convergence timeline
+### ansible-pull run (applies the playbook locally)
 
 ```
-⬜ TODO:
-# git commit <hash> pushed at HH:MM:SS
-# next timer fire at HH:MM:SS (<=5 min later)
-# state reconciled in VM: <evidence, e.g. unit now shows ADDR=:9090>
+localhost | SUCCESS => { "before": "5ca46eb...", "after": "5ca46eb...", "changed": false }
+PLAY [Deploy QuickNotes]
+  ... tasks ...
+PLAY RECAP: localhost : ok=6  changed=1  unreachable=0  failed=0
 ```
+
+(The `--limit localhost` flag was needed: `ansible-pull` defaults to `--limit <hostname>` = `quicknotes-vm`, which doesn't match the `localhost` inventory entry, so without it the play reported "no hosts matched".)
+
+### Convergence timeline (push-to-Git → VM reconciled)
+
+```
+17:55:22 UTC  VM unit file:  Environment=ADDR=:8080   (state BEFORE)
+~17:56     UTC  git commit f76d8b3 (listen_addr → :9090) pushed to feature/lab7
+18:00:17 UTC  ansible-pull.timer fires (automatic, no human action)
+18:01:51 UTC  VM unit file:  Environment=ADDR=:9090   (state AFTER — reconciled from Git)
+```
+
+The VM converged to the new Git state within the 5-minute window with zero commands run by hand — pure pull-based GitOps. (The change was then reverted to `:8080` via another commit, which the VM also picked up on the next tick.)
 
 ### Design questions
 
 **h) `ansible-pull` is pull mode — security benefit vs push?**
 
-In push mode a control node holds SSH credentials and connects *into* every managed host — that control node is a high-value target (compromise it and you can reach everything), and every host must accept inbound SSH from it. In pull mode each host runs `ansible-pull` locally and *fetches* its config from Git, so: no inbound SSH is needed (hosts can sit behind firewalls/NAT with no open management port), there's no central node holding keys to the whole fleet, and the blast radius shrinks — a host only ever pulls its own config. The trust boundary moves to "read access to the Git repo," which is easier to lock down than fleet-wide SSH.
+In push mode a control node holds SSH credentials and connects *into* every managed host — that node is a high-value target (compromise it, reach everything), and every host must accept inbound SSH. In pull mode each host runs `ansible-pull` locally and *fetches* config from Git: no inbound SSH needed (hosts can sit behind firewalls/NAT with no open management port), no central node holding fleet-wide keys, and the blast radius shrinks — a host only ever pulls its own config. The trust boundary becomes "read access to the Git repo," which is far easier to lock down than fleet-wide SSH.
 
 **i) Same pattern at the Kubernetes layer — what's it called, why is ansible-pull a fair simulator?**
 
-At the Kubernetes layer this is **GitOps**, implemented by tools like **ArgoCD** or **Flux**: a controller running in the cluster continuously watches a Git repo and reconciles the cluster's actual state to match the declared state in Git. `ansible-pull` is a fair VM-layer simulator because it embodies the same core loop — the managed node itself periodically pulls declarative config from Git and converges to it, with no human pushing and no external control node. The systemd timer firing every 5 minutes plays the role of the reconciliation loop; Git is the single source of truth in both cases.
+At the Kubernetes layer this is **GitOps**, implemented by **ArgoCD** or **Flux**: an in-cluster controller continuously watches a Git repo and reconciles actual cluster state to the declared state in Git. `ansible-pull` is a fair VM-layer simulator because it embodies the same core loop — the managed node itself periodically pulls declarative config from Git and converges to it, with no human pushing and no external control node. The systemd timer plays the role of the reconciliation loop; Git is the single source of truth in both cases.
 
 ---
 
@@ -140,6 +186,6 @@ At the Kubernetes layer this is **GitOps**, implemented by tools like **ArgoCD**
 
 | Task | Status |
 |------|--------|
-| Task 1 — idempotent Ansible deploy, service running | ⬜ |
-| Task 2 — changed=0, selective handler, --check --diff | ⬜ |
-| Bonus — ansible-pull systemd timer, convergence demoed | ⬜ |
+| Task 1 — idempotent Ansible deploy, service active (running), health ok | ✅ |
+| Task 2 — changed=0, selective handler fire, --check --diff captured | ✅ |
+| Bonus — ansible-pull systemd timer active, push→reconcile in <5 min observed | ✅ |

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,145 @@
+# Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
+
+> **Note on approach.** The host is Windows + VirtualBox with Ansible running in WSL2.
+> WSL2's separate network stack cannot reach the Vagrant VM's forwarded SSH port
+> (Windows firewall blocks the WSL subnet entirely — `ping` to the host gateway
+> returns 100% loss). Rather than weaken the host firewall, this lab uses the
+> **ansible_local / self-reconcile** model: Ansible runs *inside* the Lab 5 VM and
+> applies the playbook to `localhost` via `connection: local`. The playbook,
+> Jinja2 template, idempotency, handlers, variables, and `--check --diff` are all
+> exactly as the spec requires — only the control node location differs (it is the
+> VM itself). This is also the natural model for the bonus `ansible-pull` loop,
+> which runs inside the VM by design.
+
+## Task 1 — Idempotent Deploy
+
+### Layout
+
+```
+ansible/
+├── inventory.ini
+├── playbook.yaml
+├── files/
+│   ├── quicknotes        (static binary, built in the VM)
+│   └── seed.json
+└── templates/
+    └── quicknotes.service.j2
+```
+
+### playbook.yaml / inventory.ini / template
+
+See [`ansible/playbook.yaml`](../ansible/playbook.yaml), [`ansible/inventory.ini`](../ansible/inventory.ini), [`ansible/templates/quicknotes.service.j2`](../ansible/templates/quicknotes.service.j2).
+
+### First-run PLAY RECAP
+
+```
+⬜ TODO — paste the first ansible-playbook run output (tasks showing changed)
+# localhost : ok=6  changed=5  unreachable=0  failed=0 ...
+```
+
+### curl proving reachability
+
+```
+⬜ TODO — from host: curl http://localhost:18080/health  -> {"notes":4,"status":"ok"}
+# (or from inside VM: curl http://localhost:8080/health)
+```
+
+### Design questions
+
+**a) `command:` vs dedicated modules — which is idempotent and why it matters?**
+
+`command:` (and `shell:`) just run an arbitrary command every time the play runs — Ansible has no idea what the command *means*, so it can't tell whether the desired state is already met; it reports `changed` on every run (unless you hand-write `creates:`/`changed_when:`). Dedicated modules (`apt`, `file`, `copy`, `systemd`, `template`) are **declarative and idempotent**: they describe a desired end state, check the current state first, and only act if there's a drift — so a second run with nothing to do reports `changed=0`. That matters because idempotency is the whole point of configuration management: you can run the playbook repeatedly and safely, it converges to the target state without redoing work or causing churn (e.g. needless service restarts).
+
+**b) `notify:` and handlers — when does a handler fire, when not, why is that the right default?**
+
+A handler fires only if the task that notifies it actually reported `changed`. If the task is `ok` (no change), the notification isn't sent and the handler doesn't run. Handlers also run **once**, at the end of the play (after all tasks), even if notified multiple times. This is the right default because handlers represent reactions to change — you want to restart the service only when the binary or unit file actually changed, not on every run. Restarting an unchanged service would cause needless downtime and defeat idempotency.
+
+**c) Variable hierarchy — top 3 places for this lab's variables, and why?**
+
+Ansible has 22+ precedence levels; for this lab the three sensible homes, lowest-to-highest, are: (1) **role/play `defaults`** — sane baseline values that are easy to override (e.g. `quicknotes_listen_addr: ":8080"`); (2) **`group_vars/`** — values shared by all hosts in the `quicknotes_vm` group, good for environment-wide settings; (3) **playbook `vars:`** — values specific to this play, which override the two above. Here I put everything in playbook `vars:` for simplicity (single host, single play), but in a larger setup defaults + group_vars would let multiple environments share the playbook while overriding just what differs.
+
+**d) `gather_facts: true` is default — do you need it here? What does off save?**
+
+This playbook references no `ansible_*` facts (no `ansible_distribution`, `ansible_default_ipv4`, etc.) — every value is a variable I set myself. So fact-gathering is unnecessary and I set `gather_facts: false`. Turning it off skips the implicit `setup` task that runs at the start of every play, which probes the host for hundreds of facts — saving a few seconds and one module execution per run. On a fast local connection it's small, but it's free and correct to skip what you don't use.
+
+---
+
+## Task 2 — Prove Idempotency + Selective Re-run
+
+### Second run = changed=0
+
+```
+⬜ TODO — paste second-run PLAY RECAP
+# localhost : ok=6  changed=0  unreachable=0  failed=0 ...
+```
+
+### Variable tweak = selective change (listen_addr :8080 -> :9090)
+
+```
+⬜ TODO — paste run after editing quicknotes_listen_addr
+# template task: changed=1
+# "restart quicknotes" handler: RUNNING HANDLER ... invoked
+# other tasks: ok
+# RECAP: ok=6  changed=1 (+handler)  ...
+```
+
+### --check --diff preview (third change)
+
+```
+⬜ TODO — paste: ansible-playbook ... --check --diff
+# shows a unified diff of the unit file change without applying it
+```
+
+### Design questions
+
+**e) Why does the second run report changed=0? What does file/template check?**
+
+On the second run each module compares desired vs actual state and finds no drift. The `file` module checks the path's existence, type (directory), owner, group, and mode — all already match, so no change. The `copy` module compares the source file's checksum (SHA) against the destination's; identical checksums → no copy. The `template` module renders the Jinja2 template in memory, then compares the rendered result's checksum against the existing file's content (plus owner/group/mode); if the rendered output is byte-identical and metadata matches, it reports `ok`. Since nothing changed between runs, everything is `ok` and the recap shows `changed=0`.
+
+**f) What if you used `shell: 'echo "ADDR=..." > /etc/systemd/system/quicknotes.service'` instead of `template:`?**
+
+Several failure modes: (1) **No idempotency** — `shell` runs every time and reports `changed` every run, so you can never prove convergence and the handler would fire on every run, restarting the service needlessly. (2) **No change detection** — Ansible can't tell if the file already has the right content, so `--check`/`--diff` show nothing useful. (3) **Fragile quoting/escaping** — building a multi-line unit file with `echo`/redirection is error-prone; special characters, newlines, and variable interpolation break easily. (4) **No metadata management** — you'd separately have to `chmod`/`chown`, more steps that aren't idempotent. (5) **Partial-write risk** — a redirect that fails midway can leave a truncated unit file. The `template` module renders atomically, manages owner/group/mode, and is fully idempotent.
+
+**g) `--check` is dry-run, `--diff` shows changes — what bug does `--check --diff` catch that plain `--check` misses?**
+
+Plain `--check` tells you *that* a task would change something (`changed=1`), but not *what*. `--diff` shows the actual content difference. The bug you catch: a template change that's subtly wrong — e.g. you edit a variable and `--check` says "template would change", but only `--diff` reveals the rendered unit now has a typo, a wrong port, or an accidentally dropped line. Without the diff you'd approve a change blind and only discover the breakage after deploying. `--check --diff` lets you eyeball the exact rendered output before it touches production.
+
+---
+
+## Bonus Task — ansible-pull GitOps Loop
+
+### systemctl list-timers output
+
+```
+⬜ TODO — paste: systemctl list-timers | grep ansible-pull
+# NEXT ... LEFT ... ansible-pull.timer ansible-pull.service
+```
+
+### Convergence timeline
+
+```
+⬜ TODO:
+# git commit <hash> pushed at HH:MM:SS
+# next timer fire at HH:MM:SS (<=5 min later)
+# state reconciled in VM: <evidence, e.g. unit now shows ADDR=:9090>
+```
+
+### Design questions
+
+**h) `ansible-pull` is pull mode — security benefit vs push?**
+
+In push mode a control node holds SSH credentials and connects *into* every managed host — that control node is a high-value target (compromise it and you can reach everything), and every host must accept inbound SSH from it. In pull mode each host runs `ansible-pull` locally and *fetches* its config from Git, so: no inbound SSH is needed (hosts can sit behind firewalls/NAT with no open management port), there's no central node holding keys to the whole fleet, and the blast radius shrinks — a host only ever pulls its own config. The trust boundary moves to "read access to the Git repo," which is easier to lock down than fleet-wide SSH.
+
+**i) Same pattern at the Kubernetes layer — what's it called, why is ansible-pull a fair simulator?**
+
+At the Kubernetes layer this is **GitOps**, implemented by tools like **ArgoCD** or **Flux**: a controller running in the cluster continuously watches a Git repo and reconciles the cluster's actual state to match the declared state in Git. `ansible-pull` is a fair VM-layer simulator because it embodies the same core loop — the managed node itself periodically pulls declarative config from Git and converges to it, with no human pushing and no external control node. The systemd timer firing every 5 minutes plays the role of the reconciliation loop; Git is the single source of truth in both cases.
+
+---
+
+## Summary
+
+| Task | Status |
+|------|--------|
+| Task 1 — idempotent Ansible deploy, service running | ⬜ |
+| Task 2 — changed=0, selective handler, --check --diff | ⬜ |
+| Bonus — ansible-pull systemd timer, convergence demoed | ⬜ |


### PR DESCRIPTION
## Lab 7 — Configuration Management: Deploy QuickNotes via Ansible

### Task 1 (6) — Idempotent deploy
- ansible/playbook.yaml: creates system user, data dir, copies static binary, renders systemd unit from Jinja2, enables+starts service, handler restarts only on binary/unit change
- Approach: ansible_local (Ansible runs inside the Lab 5 VM, connection: local) — WSL2 couldn't reach the VM SSH port (host firewall blocks WSL subnet)
- First run ok=7 changed=7; service active (running); /health returns 200
- Design questions a-d answered

### Task 2 (4) — Idempotency + selective re-run
- Second run: changed=0
- listen_addr tweak: only template changed + restart handler fired (changed=2)
- --check --diff preview captured
- Design questions e, f, g answered

### Bonus (2) — ansible-pull GitOps
- systemd service + timer (every 5 min) runs ansible-pull against feature/lab7
- Convergence demoed: commit pushed → timer fired → VM reconciled :8080→:9090 in <5 min, zero manual commands
- Design questions h, i answered

Submission: submissions/lab7.md