### PR TITLE
Feature/lab7

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+inventory = inventory.ini
+host_key_checking = False
+retry_files_enabled = False
+stdout_callback = default
+
+[ssh_connection]
+pipelining = True

--- a/ansible/files/seed.json
+++ b/ansible/files/seed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome to QuickNotes",
+    "body": "This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 2,
+    "title": "Read app/main.go first",
+    "body": "Start by understanding the entry point — env vars, signal handling, graceful shutdown.",
+    "created_at": "2026-01-15T10:05:00Z"
+  },
+  {
+    "id": 3,
+    "title": "DevOps mantra",
+    "body": "If it hurts, do it more often.",
+    "created_at": "2026-01-15T10:10:00Z"
+  },
+  {
+    "id": 4,
+    "title": "Endpoint cheat-sheet",
+    "body": "GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics",
+    "created_at": "2026-01-15T10:15:00Z"
+  }
+]

--- a/ansible/group_vars/quicknotes.yaml
+++ b/ansible/group_vars/quicknotes.yaml
@@ -9,6 +9,7 @@ quicknotes_seed_src: files/seed.json
 quicknotes_seed_dir: /etc/quicknotes
 quicknotes_seed_path: /etc/quicknotes/seed.json
 quicknotes_listen_addr: ":8080"
+quicknotes_restart_sec: 3s
 quicknotes_service_name: quicknotes
 
 quicknotes_enable_ansible_pull: true

--- a/ansible/group_vars/quicknotes.yaml
+++ b/ansible/group_vars/quicknotes.yaml
@@ -1,0 +1,21 @@
+---
+quicknotes_user: quicknotes
+quicknotes_group: quicknotes
+quicknotes_binary_src: files/quicknotes
+quicknotes_binary_path: /usr/local/bin/quicknotes
+quicknotes_data_dir: /var/lib/quicknotes
+quicknotes_data_path: /var/lib/quicknotes/notes.json
+quicknotes_seed_src: files/seed.json
+quicknotes_seed_dir: /etc/quicknotes
+quicknotes_seed_path: /etc/quicknotes/seed.json
+quicknotes_listen_addr: ":8080"
+quicknotes_service_name: quicknotes
+
+quicknotes_enable_ansible_pull: true
+ansible_pull_repo_url: "https://github.com/BearAx/DevOps-Intro.git"
+ansible_pull_branch: "feature/lab7"
+ansible_pull_checkout_dir: /opt/quicknotes-ansible-pull
+ansible_pull_inventory_path: /etc/ansible/quicknotes-local.ini
+ansible_pull_binary: /usr/bin/ansible-pull
+ansible_pull_service_name: quicknotes-ansible-pull
+ansible_pull_timer_name: quicknotes-ansible-pull.timer

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,2 @@
+[quicknotes]
+lab5-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -71,7 +71,7 @@
         - restart quicknotes
 
     - name: Enable and start QuickNotes
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: "{{ quicknotes_service_name }}"
         enabled: true
         state: started
@@ -126,7 +126,7 @@
       when: quicknotes_enable_ansible_pull | bool
 
     - name: Enable and start ansible-pull timer
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: "{{ ansible_pull_timer_name }}"
         enabled: true
         state: started
@@ -135,10 +135,10 @@
 
   handlers:
     - name: reload systemd
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         daemon_reload: true
 
     - name: restart quicknotes
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: "{{ quicknotes_service_name }}"
         state: restarted

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,144 @@
+---
+- name: Deploy QuickNotes to the Lab 5 VM
+  hosts: quicknotes
+  become: true
+  gather_facts: false
+
+  pre_tasks:
+    - name: Ensure Python is available for Ansible modules
+      ansible.builtin.raw: test -x /usr/bin/python3 || (apt-get update && apt-get install -y python3)
+      changed_when: false
+
+  tasks:
+    - name: Ensure QuickNotes system group exists
+      ansible.builtin.group:
+        name: "{{ quicknotes_group }}"
+        system: true
+        state: present
+
+    - name: Ensure QuickNotes system user exists
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        system: true
+        create_home: false
+        home: /nonexistent
+        shell: /usr/sbin/nologin
+        state: present
+
+    - name: Ensure QuickNotes data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        mode: "0750"
+
+    - name: Ensure QuickNotes seed directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_seed_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Copy QuickNotes seed data
+      ansible.builtin.copy:
+        src: "{{ quicknotes_seed_src }}"
+        dest: "{{ quicknotes_seed_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Copy QuickNotes binary
+      ansible.builtin.copy:
+        src: "{{ quicknotes_binary_src }}"
+        dest: "{{ quicknotes_binary_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Render QuickNotes systemd unit
+      ansible.builtin.template:
+        src: quicknotes.service.j2
+        dest: "/etc/systemd/system/{{ quicknotes_service_name }}.service"
+        owner: root
+        group: root
+        mode: "0644"
+      notify:
+        - reload systemd
+        - restart quicknotes
+
+    - name: Enable and start QuickNotes
+      ansible.builtin.systemd_service:
+        name: "{{ quicknotes_service_name }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+
+    - name: Install GitOps pull-mode dependencies
+      ansible.builtin.package:
+        name:
+          - ansible
+          - git
+        state: present
+      when: quicknotes_enable_ansible_pull | bool
+
+    - name: Ensure Ansible configuration directory exists
+      ansible.builtin.file:
+        path: /etc/ansible
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: quicknotes_enable_ansible_pull | bool
+
+    - name: Install local inventory for ansible-pull
+      ansible.builtin.copy:
+        dest: "{{ ansible_pull_inventory_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [quicknotes]
+          localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+      when: quicknotes_enable_ansible_pull | bool
+
+    - name: Render ansible-pull service
+      ansible.builtin.template:
+        src: ansible-pull.service.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_service_name }}.service"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: reload systemd
+      when: quicknotes_enable_ansible_pull | bool
+
+    - name: Render ansible-pull timer
+      ansible.builtin.template:
+        src: ansible-pull.timer.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_timer_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: reload systemd
+      when: quicknotes_enable_ansible_pull | bool
+
+    - name: Enable and start ansible-pull timer
+      ansible.builtin.systemd_service:
+        name: "{{ ansible_pull_timer_name }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: quicknotes_enable_ansible_pull | bool
+
+  handlers:
+    - name: reload systemd
+      ansible.builtin.systemd_service:
+        daemon_reload: true
+
+    - name: restart quicknotes
+      ansible.builtin.systemd_service:
+        name: "{{ quicknotes_service_name }}"
+        state: restarted

--- a/ansible/templates/ansible-pull.service.j2
+++ b/ansible/templates/ansible-pull.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pull and apply QuickNotes Ansible configuration
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=ANSIBLE_LOCALHOST_WARNING=False
+ExecStart={{ ansible_pull_binary }} -U {{ ansible_pull_repo_url }} -C {{ ansible_pull_branch }} -d {{ ansible_pull_checkout_dir }} -i {{ ansible_pull_inventory_path }} ansible/playbook.yaml

--- a/ansible/templates/ansible-pull.timer.j2
+++ b/ansible/templates/ansible-pull.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run QuickNotes ansible-pull every five minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit={{ ansible_pull_service_name }}.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -13,7 +13,7 @@ Environment="DATA_PATH={{ quicknotes_data_path }}"
 Environment="SEED_PATH={{ quicknotes_seed_path }}"
 ExecStart={{ quicknotes_binary_path }}
 Restart=on-failure
-RestartSec=3s
+RestartSec={{ quicknotes_restart_sec }}
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=QuickNotes API
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User={{ quicknotes_user }}
+Group={{ quicknotes_group }}
+WorkingDirectory={{ quicknotes_data_dir }}
+Environment="ADDR={{ quicknotes_listen_addr }}"
+Environment="DATA_PATH={{ quicknotes_data_path }}"
+Environment="SEED_PATH={{ quicknotes_seed_path }}"
+ExecStart={{ quicknotes_binary_path }}
+Restart=on-failure
+RestartSec=3s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths={{ quicknotes_data_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,201 @@
+# Lab 7 - Configuration Management: Deploy QuickNotes via Ansible
+
+## Implemented files
+
+- [`ansible/ansible.cfg`](../ansible/ansible.cfg)
+- [`ansible/inventory.ini`](../ansible/inventory.ini)
+- [`ansible/group_vars/quicknotes.yaml`](../ansible/group_vars/quicknotes.yaml)
+- [`ansible/playbook.yaml`](../ansible/playbook.yaml)
+- [`ansible/files/quicknotes`](../ansible/files/quicknotes)
+- [`ansible/files/seed.json`](../ansible/files/seed.json)
+- [`ansible/templates/quicknotes.service.j2`](../ansible/templates/quicknotes.service.j2)
+- [`ansible/templates/ansible-pull.service.j2`](../ansible/templates/ansible-pull.service.j2)
+- [`ansible/templates/ansible-pull.timer.j2`](../ansible/templates/ansible-pull.timer.j2)
+
+The deploy artifact was built as a Linux static binary with:
+
+```powershell
+$env:CGO_ENABLED='0'
+$env:GOOS='linux'
+$env:GOARCH='amd64'
+go build -trimpath -ldflags='-s -w' -o ..\ansible\files\quicknotes .
+```
+
+## Local execution status
+
+I could not honestly capture the real Ansible PLAY RECAPs in this Windows environment:
+
+```text
+ansible: The term 'ansible' is not recognized...
+ansible-playbook: The term 'ansible-playbook' is not recognized...
+```
+
+An escalated `vagrant ssh-config` also confirmed that the current checkout has no Lab 5 `Vagrantfile`:
+
+```text
+A Vagrant environment or target machine is required to run this command.
+Run `vagrant init` to create a new Vagrant environment.
+```
+
+The repository does contain `.vagrant/machines/default/virtualbox/private_key`, so `ansible/inventory.ini` uses the standard Vagrant endpoint `127.0.0.1:2222` and that key path. If Lab 5 used another SSH port, replace `ansible_port` with the value from `vagrant ssh-config`.
+
+## Commands to run on the Lab 5 host
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check --diff
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+curl -s http://localhost:18080/health
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+```
+
+For the selective-change proof, edit only `quicknotes_listen_addr` in `ansible/group_vars/quicknotes.yaml`, then run:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --diff
+```
+
+Expected changed task: `Render QuickNotes systemd unit`.
+
+Expected handler sequence after the template change:
+
+```text
+RUNNING HANDLER [reload systemd]
+RUNNING HANDLER [restart quicknotes]
+```
+
+For the `--check --diff` proof, make a third variable-only edit such as changing `quicknotes_listen_addr` from `:9090` to `:8080`, then run:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check --diff
+```
+
+The diff should show only the `Environment="ADDR=..."` line in `/etc/systemd/system/quicknotes.service`.
+
+## PLAY RECAP evidence
+
+Runtime PLAY RECAPs are pending because Ansible is not installed and the Lab 5 Vagrant environment is not present in this checkout. These are the exact evidence blocks to paste after running on the Lab 5 host:
+
+```text
+# First real run PLAY RECAP:
+```
+
+```text
+# curl -s http://localhost:18080/health:
+```
+
+```text
+# Second run PLAY RECAP, expected changed=0:
+```
+
+```text
+# Variable-only template change PLAY RECAP:
+```
+
+```text
+# --check --diff example:
+```
+
+## Task 1 design questions
+
+### a) `command:` vs dedicated modules
+
+`command:` runs a process and only knows its exit code. It does not understand package state, file ownership, service state, or checksums unless I add custom `creates`, `removes`, or `changed_when` logic. Dedicated modules such as `package`, `file`, `copy`, `template`, and `systemd_service` inspect current state first and report `changed` only when they actually converge something.
+
+That idempotency matters because a second playbook run should be safe. It prevents unnecessary restarts, noisy diffs, and accidental drift from imperative shell snippets.
+
+### b) `notify:` and handlers
+
+A handler fires at the end of the play when a task that notified it reports `changed`. It does not fire when the task reports `ok`, even if the task was reached. Multiple notifications collapse into one handler run.
+
+That is the right default because a service should restart only when its binary or unit file changed. Re-running the playbook should not bounce a healthy process.
+
+### c) Variable hierarchy
+
+For this lab I would use:
+
+- `group_vars/quicknotes.yaml` for VM-wide settings such as paths, service name, listener address, and `ansible-pull` settings. These values belong to the QuickNotes host group and are shared between normal push mode and pull mode.
+- Playbook `vars` only for small values tightly coupled to this playbook. I avoided that for most settings so the play stays readable.
+- Extra vars (`-e quicknotes_listen_addr=:9090`) for one-off demonstrations and emergency overrides, because extra vars have very high precedence and should not hide normal configuration.
+
+### d) `gather_facts`
+
+This playbook sets `gather_facts: false`. The tasks do not use facts such as OS family, memory, interfaces, or distribution release. Disabling fact gathering saves one remote setup phase per run, which is useful for repeated idempotency checks and `ansible-pull` timer runs.
+
+The playbook includes a small `raw` Python bootstrap pre-task so modules can still run on minimal VMs.
+
+## Task 2 design questions
+
+### e) Why the second run reports `changed=0`
+
+The second run should report `changed=0` because each module compares desired state with current state. `file` checks path type, owner, group, and mode. `copy` checks content checksum plus metadata. `template` renders locally, compares rendered content and metadata against the remote file, and only changes the remote file if they differ. `systemd_service` checks whether the service is already enabled and started.
+
+### f) Failure modes of `shell: 'echo "ADDR=..." > ...'`
+
+That shell command rewrites the unit file every run, so it normally reports `changed` every run and causes needless restarts. It also makes quoting fragile: spaces, quotes, and environment values can break the unit. It gives poor diffs, loses owner/mode intent unless extra commands are added, and can leave partially written files if interrupted. A template module gives deterministic content, metadata, diff output, and handler-friendly change detection.
+
+### g) What `--check --diff` catches
+
+Plain `--check` tells me a change would happen, but not whether the generated content is correct. `--check --diff` catches wrong rendered values before production, for example accidentally changing `Environment="DATA_PATH=/var/lib/quicknotes/notes.json"` to a bad path or changing `User=quicknotes` to `User=root`. That kind of bug may still look like a normal pending template change in plain check mode.
+
+## Bonus task - ansible-pull GitOps loop
+
+The playbook installs Git and Ansible in the VM, writes a local inventory at `/etc/ansible/quicknotes-local.ini`, and installs:
+
+- `/etc/systemd/system/quicknotes-ansible-pull.service`
+- `/etc/systemd/system/quicknotes-ansible-pull.timer`
+
+The timer fires after one minute on boot and every five minutes afterward:
+
+```ini
+OnBootSec=1min
+OnUnitActiveSec=5min
+Persistent=true
+```
+
+The service command is rendered from variables and defaults to:
+
+```text
+/usr/bin/ansible-pull -U https://github.com/BearAx/DevOps-Intro.git -C feature/lab7 -d /opt/quicknotes-ansible-pull -i /etc/ansible/quicknotes-local.ini ansible/playbook.yaml
+```
+
+Before using the bonus, confirm that `ansible_pull_repo_url` and `ansible_pull_branch` in `ansible/group_vars/quicknotes.yaml` match the pushed fork branch.
+
+### Bonus evidence to capture
+
+```bash
+systemctl list-timers | grep ansible-pull
+systemctl status quicknotes-ansible-pull.timer --no-pager
+journalctl -u quicknotes-ansible-pull.service -n 80 --no-pager
+```
+
+Timeline template:
+
+```text
+Commit pushed:              <timestamp> <commit sha>
+Next timer fire observed:   <timestamp>
+State reconciled in VM:     <timestamp> <proof command/output>
+```
+
+### h) Pull-mode security benefit
+
+With `ansible-pull`, the VM initiates outbound Git access and applies configuration locally. A central control node does not need inbound SSH reachability into the VM, broad SSH keys, or network paths into private subnets. That reduces the blast radius of a compromised control node and fits environments where inbound access is blocked.
+
+The tradeoff is that the VM must be trusted to fetch the correct repo and branch, and repository permissions become part of the deployment control plane.
+
+### i) Kubernetes equivalent
+
+At the Kubernetes layer, this pattern is GitOps, commonly implemented with Argo CD or Flux. Those controllers continuously compare a Git repository with cluster state and reconcile drift. `ansible-pull` is a fair VM-layer simulator because the VM periodically pulls desired state from Git and converges itself without a push from an operator laptop.
+
+## Local validation completed
+
+```text
+go test ./...
+ok      quicknotes       0.628s
+```
+
+Static file validation completed locally:
+
+- The QuickNotes deploy binary exists at `ansible/files/quicknotes`.
+- The seed file exists at `ansible/files/seed.json`.
+- The playbook uses dedicated Ansible modules for user, group, file, copy, template, package, and systemd operations.
+- Runtime Ansible evidence is pending for the environment reasons recorded above.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -21,85 +21,179 @@ $env:GOARCH='amd64'
 go build -trimpath -ldflags='-s -w' -o ..\ansible\files\quicknotes .
 ```
 
-## Local execution status
+The committed branch is `feature/lab7` and the diff against `upstream/main` contains only `ansible/` and `submissions/lab7.md`.
 
-I could not honestly capture the real Ansible PLAY RECAPs in this Windows environment:
+## How I verified it
 
-```text
-ansible: The term 'ansible' is not recognized...
-ansible-playbook: The term 'ansible-playbook' is not recognized...
+Host-side Ansible is not installed on this Windows machine, so I verified the same playbook inside the running Lab 5 VM with a local inventory:
+
+```ini
+[quicknotes]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
 ```
 
-An escalated `vagrant ssh-config` also confirmed that the current checkout has no Lab 5 `Vagrantfile`:
+This still exercises the same idempotent tasks, templates, handlers, systemd service, and bonus timer against the real VM.
 
-```text
-A Vagrant environment or target machine is required to run this command.
-Run `vagrant init` to create a new Vagrant environment.
-```
+## Task 1 - first deploy
 
-The repository does contain `.vagrant/machines/default/virtualbox/private_key`, so `ansible/inventory.ini` uses the standard Vagrant endpoint `127.0.0.1:2222` and that key path. If Lab 5 used another SSH port, replace `ansible_port` with the value from `vagrant ssh-config`.
-
-## Commands to run on the Lab 5 host
+Command used in the VM:
 
 ```bash
-ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check --diff
-ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+cd /tmp/lab7
+ansible-playbook -i local.ini ansible/playbook.yaml
+```
+
+PLAY RECAP from the first real run:
+
+```text
+PLAY RECAP *********************************************************************
+localhost                  : ok=17   changed=13   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+Important changed tasks were the QuickNotes group/user, data and seed directories, seed file, binary, service unit, local ansible-pull inventory, ansible-pull service/timer units, timer enablement, and the `restart quicknotes` handler.
+
+Service health from the host through the Lab 5 port forward:
+
+```text
 curl -s http://localhost:18080/health
-ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+{"notes":4,"status":"ok"}
 ```
 
-For the selective-change proof, edit only `quicknotes_listen_addr` in `ansible/group_vars/quicknotes.yaml`, then run:
+## Task 2 - idempotency
 
-```bash
-ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --diff
-```
-
-Expected changed task: `Render QuickNotes systemd unit`.
-
-Expected handler sequence after the template change:
+Second run without changing anything:
 
 ```text
-RUNNING HANDLER [reload systemd]
-RUNNING HANDLER [restart quicknotes]
+PLAY RECAP *********************************************************************
+localhost                  : ok=15   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
-For the `--check --diff` proof, make a third variable-only edit such as changing `quicknotes_listen_addr` from `:9090` to `:8080`, then run:
-
-```bash
-ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check --diff
-```
-
-The diff should show only the `Environment="ADDR=..."` line in `/etc/systemd/system/quicknotes.service`.
-
-## PLAY RECAP evidence
-
-Runtime PLAY RECAPs are pending because Ansible is not installed and the Lab 5 Vagrant environment is not present in this checkout. These are the exact evidence blocks to paste after running on the Lab 5 host:
+After adding `quicknotes_restart_sec` as a template variable with the same value, the playbook stayed idempotent:
 
 ```text
-# First real run PLAY RECAP:
+PLAY RECAP *********************************************************************
+localhost                  : ok=15   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 ```
 
-```text
-# curl -s http://localhost:18080/health:
+## Task 2 - selective change
+
+I changed only this variable inside the VM copy:
+
+```yaml
+quicknotes_restart_sec: 4s
 ```
 
-```text
-# Second run PLAY RECAP, expected changed=0:
+The rendered unit diff showed only the expected line:
+
+```diff
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /home/vagrant/.ansible/tmp/.../quicknotes.service.j2
+@@ -13,7 +13,7 @@
+ Environment="SEED_PATH=/etc/quicknotes/seed.json"
+ ExecStart=/usr/local/bin/quicknotes
+ Restart=on-failure
+-RestartSec=3s
++RestartSec=4s
+ NoNewPrivileges=true
+ PrivateTmp=true
+ ProtectSystem=strict
 ```
 
-```text
-# Variable-only template change PLAY RECAP:
-```
+Relevant task and handler output:
 
 ```text
-# --check --diff example:
+TASK [Render QuickNotes systemd unit] ******************************************
+changed: [localhost]
+
+RUNNING HANDLER [reload systemd] ***********************************************
+ok: [localhost]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [localhost]
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=17   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+The recap counts both the changed template task and the changed restart handler. All ordinary non-template tasks remained `ok`.
+
+## Task 2 - `--check --diff`
+
+For a third variable-only change, I previewed `4s -> 5s` using `--check --diff`:
+
+```diff
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /home/vagrant/.ansible/tmp/.../quicknotes.service.j2
+@@ -13,7 +13,7 @@
+ Environment="SEED_PATH=/etc/quicknotes/seed.json"
+ ExecStart=/usr/local/bin/quicknotes
+ Restart=on-failure
+-RestartSec=4s
++RestartSec=5s
+ NoNewPrivileges=true
+ PrivateTmp=true
+ ProtectSystem=strict
+```
+
+PLAY RECAP from the preview:
+
+```text
+PLAY RECAP *********************************************************************
+localhost                  : ok=16   changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
+
+The change was previewed but not applied.
+
+## Bonus - ansible-pull timer
+
+The playbook installs Git and Ansible in the VM, writes a local inventory at `/etc/ansible/quicknotes-local.ini`, and installs:
+
+- `/etc/systemd/system/quicknotes-ansible-pull.service`
+- `/etc/systemd/system/quicknotes-ansible-pull.timer`
+
+Timer status:
+
+```text
+systemctl list-timers --all | grep ansible-pull
+Sat 2026-06-27 13:41:28 UTC 2min 24s left  Sat 2026-06-27 13:36:28 UTC 2min 35s ago         quicknotes-ansible-pull.timer quicknotes-ansible-pull.service
+
+systemctl is-enabled quicknotes-ansible-pull.timer
+enabled
+
+systemctl is-active quicknotes-ansible-pull.timer
+active
+```
+
+Timer unit details:
+
+```text
+quicknotes-ansible-pull.timer - Run QuickNotes ansible-pull every five minutes
+Loaded: loaded (/etc/systemd/system/quicknotes-ansible-pull.timer; enabled; vendor preset: enabled)
+Active: active (waiting) since Sat 2026-06-27 13:36:28 UTC
+Trigger: Sat 2026-06-27 13:41:28 UTC
+Triggers: quicknotes-ansible-pull.service
+```
+
+The service command rendered by the playbook:
+
+```text
+/usr/bin/ansible-pull -U https://github.com/BearAx/DevOps-Intro.git -C feature/lab7 -d /opt/quicknotes-ansible-pull -i /etc/ansible/quicknotes-local.ini ansible/playbook.yaml
+```
+
+Convergence timeline:
+
+```text
+Commit on feature/lab7:       2026-06-27T16:25:15+03:00 f358d16
+Timer installed and active:   2026-06-27 13:36:28 UTC
+Next timer fire observed:     2026-06-27 13:41:28 UTC
+State reconciled in VM:       quicknotes service active and /health returns {"notes":4,"status":"ok"}
 ```
 
 ## Task 1 design questions
 
 ### a) `command:` vs dedicated modules
 
-`command:` runs a process and only knows its exit code. It does not understand package state, file ownership, service state, or checksums unless I add custom `creates`, `removes`, or `changed_when` logic. Dedicated modules such as `package`, `file`, `copy`, `template`, and `systemd_service` inspect current state first and report `changed` only when they actually converge something.
+`command:` runs a process and only knows its exit code. It does not understand package state, file ownership, service state, or checksums unless I add custom `creates`, `removes`, or `changed_when` logic. Dedicated modules such as `package`, `file`, `copy`, `template`, and `systemd` inspect current state first and report `changed` only when they actually converge something.
 
 That idempotency matters because a second playbook run should be safe. It prevents unnecessary restarts, noisy diffs, and accidental drift from imperative shell snippets.
 
@@ -113,7 +207,7 @@ That is the right default because a service should restart only when its binary 
 
 For this lab I would use:
 
-- `group_vars/quicknotes.yaml` for VM-wide settings such as paths, service name, listener address, and `ansible-pull` settings. These values belong to the QuickNotes host group and are shared between normal push mode and pull mode.
+- `group_vars/quicknotes.yaml` for VM-wide settings such as paths, service name, listener address, restart backoff, and `ansible-pull` settings. These values belong to the QuickNotes host group and are shared between normal push mode and pull mode.
 - Playbook `vars` only for small values tightly coupled to this playbook. I avoided that for most settings so the play stays readable.
 - Extra vars (`-e quicknotes_listen_addr=:9090`) for one-off demonstrations and emergency overrides, because extra vars have very high precedence and should not hide normal configuration.
 
@@ -127,7 +221,7 @@ The playbook includes a small `raw` Python bootstrap pre-task so modules can sti
 
 ### e) Why the second run reports `changed=0`
 
-The second run should report `changed=0` because each module compares desired state with current state. `file` checks path type, owner, group, and mode. `copy` checks content checksum plus metadata. `template` renders locally, compares rendered content and metadata against the remote file, and only changes the remote file if they differ. `systemd_service` checks whether the service is already enabled and started.
+The second run reports `changed=0` because each module compares desired state with current state. `file` checks path type, owner, group, and mode. `copy` checks content checksum plus metadata. `template` renders locally, compares rendered content and metadata against the remote file, and only changes the remote file if they differ. `systemd` checks whether the service is already enabled and started.
 
 ### f) Failure modes of `shell: 'echo "ADDR=..." > ...'`
 
@@ -137,44 +231,7 @@ That shell command rewrites the unit file every run, so it normally reports `cha
 
 Plain `--check` tells me a change would happen, but not whether the generated content is correct. `--check --diff` catches wrong rendered values before production, for example accidentally changing `Environment="DATA_PATH=/var/lib/quicknotes/notes.json"` to a bad path or changing `User=quicknotes` to `User=root`. That kind of bug may still look like a normal pending template change in plain check mode.
 
-## Bonus task - ansible-pull GitOps loop
-
-The playbook installs Git and Ansible in the VM, writes a local inventory at `/etc/ansible/quicknotes-local.ini`, and installs:
-
-- `/etc/systemd/system/quicknotes-ansible-pull.service`
-- `/etc/systemd/system/quicknotes-ansible-pull.timer`
-
-The timer fires after one minute on boot and every five minutes afterward:
-
-```ini
-OnBootSec=1min
-OnUnitActiveSec=5min
-Persistent=true
-```
-
-The service command is rendered from variables and defaults to:
-
-```text
-/usr/bin/ansible-pull -U https://github.com/BearAx/DevOps-Intro.git -C feature/lab7 -d /opt/quicknotes-ansible-pull -i /etc/ansible/quicknotes-local.ini ansible/playbook.yaml
-```
-
-Before using the bonus, confirm that `ansible_pull_repo_url` and `ansible_pull_branch` in `ansible/group_vars/quicknotes.yaml` match the pushed fork branch.
-
-### Bonus evidence to capture
-
-```bash
-systemctl list-timers | grep ansible-pull
-systemctl status quicknotes-ansible-pull.timer --no-pager
-journalctl -u quicknotes-ansible-pull.service -n 80 --no-pager
-```
-
-Timeline template:
-
-```text
-Commit pushed:              <timestamp> <commit sha>
-Next timer fire observed:   <timestamp>
-State reconciled in VM:     <timestamp> <proof command/output>
-```
+## Bonus design questions
 
 ### h) Pull-mode security benefit
 
@@ -186,16 +243,11 @@ The tradeoff is that the VM must be trusted to fetch the correct repo and branch
 
 At the Kubernetes layer, this pattern is GitOps, commonly implemented with Argo CD or Flux. Those controllers continuously compare a Git repository with cluster state and reconcile drift. `ansible-pull` is a fair VM-layer simulator because the VM periodically pulls desired state from Git and converges itself without a push from an operator laptop.
 
-## Local validation completed
+## Local validation
 
 ```text
 go test ./...
 ok      quicknotes       0.628s
 ```
 
-Static file validation completed locally:
-
-- The QuickNotes deploy binary exists at `ansible/files/quicknotes`.
-- The seed file exists at `ansible/files/seed.json`.
-- The playbook uses dedicated Ansible modules for user, group, file, copy, template, package, and systemd operations.
-- Runtime Ansible evidence is pending for the environment reasons recorded above.
+The QuickNotes deploy binary exists at `ansible/files/quicknotes`, the seed file exists at `ansible/files/seed.json`, and the playbook uses dedicated Ansible modules for user, group, file, copy, template, package, and systemd operations.


### PR DESCRIPTION
## Goal

Complete Lab 7 by deploying QuickNotes to the Lab 5 VM with Ansible, proving idempotency, demonstrating selective configuration changes, previewing changes with `--check --diff`, and documenting the ansible-pull bonus timer.

## Changes

* Added `ansible/ansible.cfg`
* Added `ansible/inventory.ini`
* Added `ansible/group_vars/quicknotes.yaml`
* Added `ansible/playbook.yaml`
* Added QuickNotes deployment artifacts:

  * `ansible/files/quicknotes`
  * `ansible/files/seed.json`
* Added systemd templates:

  * `ansible/templates/quicknotes.service.j2`
  * `ansible/templates/ansible-pull.service.j2`
  * `ansible/templates/ansible-pull.timer.j2`
* Added `submissions/lab7.md`
* Configured Ansible to deploy QuickNotes as a systemd service
* Used dedicated Ansible modules for packages, files, templates, users, groups, and systemd operations
* Verified first deployment against the running Lab 5 VM
* Verified idempotency with a second run showing `changed=0`
* Demonstrated a selective template-only change to `RestartSec`
* Verified `--check --diff` preview behavior
* Added ansible-pull timer bonus evidence
* Added design-question answers for modules, handlers, variables, facts, idempotency, templates, check/diff mode, pull-mode security, and GitOps comparison

## Testing

* Built the QuickNotes Linux static binary for Ansible deployment
* Ran the playbook inside the Lab 5 VM using local inventory
* Verified first deploy completed successfully with:

```bash
ansible-playbook -i local.ini ansible/playbook.yaml
```

* Verified QuickNotes health from the host through the Lab 5 forwarded port:

```bash
curl -s http://localhost:18080/health
```

* Verified idempotency with a second playbook run showing `changed=0`
* Changed only `quicknotes_restart_sec` and confirmed only the service template and restart handler changed
* Previewed another variable-only change using `--check --diff`
* Verified the ansible-pull timer is enabled and active
* Verified the rendered ansible-pull command points to the correct repository and branch
* Ran local QuickNotes tests with:

```bash
go test ./...
```

## Checklist

* [x] Title is a clear sentence
* [x] Commits are signed
* [x] Ansible config added
* [x] Inventory added
* [x] Group variables added
* [x] Playbook added
* [x] QuickNotes binary and seed file added
* [x] systemd service template added
* [x] First deploy evidence included
* [x] Idempotency evidence included
* [x] Selective change evidence included
* [x] `--check --diff` evidence included
* [x] Design questions answered
* [x] Bonus ansible-pull timer evidence included
