### PR TITLE
Arseny Pinigin Lab 7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (<= 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,19 @@ Vagrant.configure("2") do |config|
     set -euo pipefail
 
     GO_VERSION="#{GO_VERSION}"
-    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+    case "$(uname -m)" in
+      x86_64)
+        GO_ARCH="amd64"
+        ;;
+      aarch64|arm64)
+        GO_ARCH="arm64"
+        ;;
+      *)
+        echo "Unsupported guest architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+    esac
+    GO_TARBALL="go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
 
     export DEBIAN_FRONTEND=noninteractive
     apt-get update -y

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# Lab 5 — QuickNotes in a Vagrant VM.
+# Boots an Ubuntu 24.04 LTS VM, installs Go 1.24.x, builds QuickNotes from the
+# synced ./app folder, and runs it as a systemd service on guest port 8080.
+# The host reaches it on http://127.0.0.1:18080.
+
+GO_VERSION = "1.24.5"
+
+Vagrant.configure("2") do |config|
+  # Ubuntu 24.04 LTS. The bento box ships VirtualBox Guest Additions, which we
+  # need for the default (virtualbox) synced-folder type.
+  config.vm.box = "bento/ubuntu-24.04"
+
+  # Identify the VM clearly (shows up in the shell prompt and `vagrant ssh`).
+  config.vm.hostname = "quicknotes-vm"
+
+  # Forward host 18080 -> guest 8080, bound to loopback only so the app is not
+  # exposed to the local network.
+  config.vm.network "forwarded_port", guest: 8080, host: 18080, host_ip: "127.0.0.1"
+
+  # Mount the application source into the guest (default type: virtualbox).
+  config.vm.synced_folder "./app", "/opt/quicknotes/app"
+
+  # Cap resources at 2 vCPU / 1024 MB RAM (over-provisioning is an antipattern).
+  config.vm.provider "virtualbox" do |vb|
+    vb.name   = "quicknotes-vm"
+    vb.memory = 1024
+    vb.cpus   = 2
+  end
+
+  # Provisioning runs on first `vagrant up`; re-run with `vagrant provision`.
+  # The script is idempotent, so `vagrant up --provision` is safe to repeat.
+  config.vm.provision "shell", inline: <<-SHELL
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    GO_VERSION="#{GO_VERSION}"
+    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -y
+    apt-get install -y curl
+
+    # Install the pinned Go version only if it is not already present.
+    if ! /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION} "; then
+      echo "Installing Go ${GO_VERSION}..."
+      curl -fsSL "https://go.dev/dl/${GO_TARBALL}" -o "/tmp/${GO_TARBALL}"
+      rm -rf /usr/local/go
+      tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+    fi
+
+    # Make Go available on PATH for interactive logins (e.g. `vagrant ssh`).
+    echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh
+
+    # Build QuickNotes from the synced source into a stable location.
+    install -d /var/lib/quicknotes
+    /usr/local/go/bin/go build -C /opt/quicknotes/app -o /usr/local/bin/quicknotes .
+
+    # Run QuickNotes as a service so it survives reboots and starts on boot.
+    cat > /etc/systemd/system/quicknotes.service <<'UNIT'
+[Unit]
+Description=QuickNotes API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment=ADDR=:8080
+Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+Environment=SEED_PATH=/opt/quicknotes/app/seed.json
+WorkingDirectory=/var/lib/quicknotes
+ExecStart=/usr/local/bin/quicknotes
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+    systemctl daemon-reload
+    systemctl enable quicknotes
+    systemctl restart quicknotes
+
+    echo "Provisioning done. QuickNotes should be live on guest :8080."
+  SHELL
+end

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,2 @@
+[quicknotes_vm]
+quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,2 @@
 [quicknotes_vm]
-quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3
+quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa'

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -16,6 +16,15 @@
     quicknotes_data_path: /var/lib/quicknotes/notes.json
     quicknotes_seed_path: /opt/quicknotes/app/seed.json
     listen_addr: ":8080"
+    quicknotes_restart_sec: 3
+    ansible_pull_enabled: true
+    ansible_pull_repo_url: https://github.com/Hidancloud/DevOps-Intro.git
+    ansible_pull_repo_branch: feature/lab7
+    ansible_pull_checkout_dir: /var/lib/ansible-pull/quicknotes
+    ansible_pull_inventory_path: /etc/ansible/quicknotes-local.ini
+    ansible_pull_playbook_path: ansible/playbook.yaml
+    ansible_pull_service_name: ansible-pull-quicknotes.service
+    ansible_pull_timer_name: ansible-pull-quicknotes.timer
 
   tasks:
     - name: Create the quicknotes system group
@@ -69,6 +78,85 @@
         name: "{{ quicknotes_service_name }}"
         enabled: true
         state: started
+
+    - name: Install ansible-pull dependencies
+      ansible.builtin.apt:
+        name:
+          - ansible
+          - git
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_pull_enabled
+
+    - name: Ensure ansible config directory exists
+      ansible.builtin.file:
+        path: /etc/ansible
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull local inventory
+      ansible.builtin.template:
+        src: templates/quicknotes-local.ini.j2
+        dest: "{{ ansible_pull_inventory_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+      when: ansible_pull_enabled
+
+    - name: Ensure ansible-pull checkout directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_pull_checkout_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull service
+      ansible.builtin.template:
+        src: templates/ansible-pull-quicknotes.service.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_service_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: ansible_pull_service_unit
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull timer
+      ansible.builtin.template:
+        src: templates/ansible-pull-quicknotes.timer.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_timer_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: ansible_pull_timer_unit
+      when: ansible_pull_enabled
+
+    - name: Reload systemd when ansible-pull units change
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when:
+        - ansible_pull_enabled
+        - ansible_pull_service_unit.changed or ansible_pull_timer_unit.changed
+
+    - name: Prime ansible-pull once so the timer has a last-run anchor
+      ansible.builtin.systemd:
+        name: "{{ ansible_pull_service_name }}"
+        state: started
+      when:
+        - ansible_pull_enabled
+        - ansible_connection != 'local'
+
+    - name: Enable and start the ansible-pull timer
+      ansible.builtin.systemd:
+        name: "{{ ansible_pull_timer_name }}"
+        enabled: true
+        state: started
+      when: ansible_pull_enabled
 
   handlers:
     - name: restart quicknotes

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -105,6 +105,7 @@
         owner: root
         group: root
         mode: "0644"
+      register: ansible_pull_local_inventory
       when: ansible_pull_enabled
 
     - name: Ensure ansible-pull checkout directory exists
@@ -150,6 +151,7 @@
       when:
         - ansible_pull_enabled
         - ansible_connection != 'local'
+        - ansible_pull_local_inventory.changed or ansible_pull_service_unit.changed or ansible_pull_timer_unit.changed
 
     - name: Enable and start the ansible-pull timer
       ansible.builtin.systemd:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,78 @@
+- name: Deploy QuickNotes to the Lab 5 VM
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_group: quicknotes
+    quicknotes_home: /nonexistent
+    quicknotes_shell: /usr/sbin/nologin
+    quicknotes_binary_src: files/quicknotes
+    quicknotes_binary_dest: /usr/local/bin/quicknotes
+    quicknotes_service_name: quicknotes
+    quicknotes_service_unit_path: /etc/systemd/system/quicknotes.service
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_data_path: /var/lib/quicknotes/notes.json
+    quicknotes_seed_path: /opt/quicknotes/app/seed.json
+    listen_addr: ":8080"
+
+  tasks:
+    - name: Create the quicknotes system group
+      ansible.builtin.group:
+        name: "{{ quicknotes_group }}"
+        system: true
+
+    - name: Create the quicknotes system user
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        system: true
+        create_home: false
+        home: "{{ quicknotes_home }}"
+        shell: "{{ quicknotes_shell }}"
+
+    - name: Ensure the quicknotes data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        mode: "0750"
+
+    - name: Install the QuickNotes binary
+      ansible.builtin.copy:
+        src: "{{ quicknotes_binary_src }}"
+        dest: "{{ quicknotes_binary_dest }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Install the systemd unit
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: "{{ quicknotes_service_unit_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: quicknotes_service_unit
+      notify: restart quicknotes
+
+    - name: Reload systemd when the unit changes
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when: quicknotes_service_unit.changed
+
+    - name: Enable and start the quicknotes service
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        enabled: true
+        state: started
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        state: restarted
+        daemon_reload: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -16,7 +16,7 @@
     quicknotes_data_path: /var/lib/quicknotes/notes.json
     quicknotes_seed_path: /opt/quicknotes/app/seed.json
     listen_addr: ":8080"
-    quicknotes_restart_sec: 3
+    quicknotes_restart_sec: 4
     ansible_pull_enabled: true
     ansible_pull_repo_url: https://github.com/Hidancloud/DevOps-Intro.git
     ansible_pull_repo_branch: feature/lab7

--- a/ansible/templates/ansible-pull-quicknotes.service.j2
+++ b/ansible/templates/ansible-pull-quicknotes.service.j2
@@ -1,0 +1,8 @@
+[Unit]
+Description=Reconcile QuickNotes from Git via ansible-pull
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ansible-pull -U {{ ansible_pull_repo_url }} -C {{ ansible_pull_repo_branch }} -d {{ ansible_pull_checkout_dir }} -i {{ ansible_pull_inventory_path }} {{ ansible_pull_playbook_path }}

--- a/ansible/templates/ansible-pull-quicknotes.timer.j2
+++ b/ansible/templates/ansible-pull-quicknotes.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run ansible-pull for QuickNotes every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit={{ ansible_pull_service_name }}
+
+[Install]
+WantedBy=timers.target

--- a/ansible/templates/quicknotes-local.ini.j2
+++ b/ansible/templates/quicknotes-local.ini.j2
@@ -1,0 +1,2 @@
+[quicknotes_vm]
+quicknotes-vm ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=QuickNotes API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ quicknotes_user }}
+Group={{ quicknotes_group }}
+WorkingDirectory={{ quicknotes_data_dir }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ quicknotes_data_path }}
+Environment=SEED_PATH={{ quicknotes_seed_path }}
+ExecStart={{ quicknotes_binary_dest }}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -13,7 +13,7 @@ Environment=DATA_PATH={{ quicknotes_data_path }}
 Environment=SEED_PATH={{ quicknotes_seed_path }}
 ExecStart={{ quicknotes_binary_dest }}
 Restart=on-failure
-RestartSec=3
+RestartSec={{ quicknotes_restart_sec }}
 
 [Install]
 WantedBy=multi-user.target

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -49,6 +49,11 @@ The playbook performs the required idempotent steps:
 on OS facts, CPU architecture, or package manager state; skipping the setup step
 keeps runs shorter and makes the idempotency proof tighter.
 
+On this MacBook, the inventory also had to mirror `vagrant ssh-config` by
+disabling strict host-key checks for the ephemeral local VM SSH endpoint. That
+matched Vagrant's own SSH behavior and resolved an initial `Host key
+verification failed` error from Ansible.
+
 ## Repository layout
 
 ```text
@@ -198,7 +203,36 @@ GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
 ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check
 ```
 
-**TODO:** paste the output.
+```text
+PLAY [Deploy QuickNotes to the Lab 5 VM] ***************************************
+
+TASK [Create the quicknotes system group] **************************************
+changed: [quicknotes-vm]
+
+TASK [Create the quicknotes system user] ***************************************
+changed: [quicknotes-vm]
+
+TASK [Ensure the quicknotes data directory exists] *****************************
+changed: [quicknotes-vm]
+
+TASK [Install the QuickNotes binary] *******************************************
+changed: [quicknotes-vm]
+
+TASK [Install the systemd unit] ************************************************
+changed: [quicknotes-vm]
+
+TASK [Reload systemd when the unit changes] ************************************
+ok: [quicknotes-vm]
+
+TASK [Enable and start the quicknotes service] *********************************
+ok: [quicknotes-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes-vm]
+
+PLAY RECAP *********************************************************************
+quicknotes-vm              : ok=8    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
 
 ### First real run
 
@@ -206,7 +240,36 @@ ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check
 ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
 ```
 
-**TODO:** paste the full PLAY RECAP from the first run.
+```text
+PLAY [Deploy QuickNotes to the Lab 5 VM] ***************************************
+
+TASK [Create the quicknotes system group] **************************************
+changed: [quicknotes-vm]
+
+TASK [Create the quicknotes system user] ***************************************
+changed: [quicknotes-vm]
+
+TASK [Ensure the quicknotes data directory exists] *****************************
+changed: [quicknotes-vm]
+
+TASK [Install the QuickNotes binary] *******************************************
+changed: [quicknotes-vm]
+
+TASK [Install the systemd unit] ************************************************
+changed: [quicknotes-vm]
+
+TASK [Reload systemd when the unit changes] ************************************
+ok: [quicknotes-vm]
+
+TASK [Enable and start the quicknotes service] *********************************
+ok: [quicknotes-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes-vm]
+
+PLAY RECAP *********************************************************************
+quicknotes-vm              : ok=8    changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
 
 ### Reachability proof
 
@@ -214,8 +277,9 @@ ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
 curl -s http://localhost:18080/health
 ```
 
-**TODO:** paste the output proving the service is reachable through the Vagrant
-port-forward.
+```text
+{"notes":4,"status":"ok"}
+```
 
 ### Design questions
 
@@ -265,7 +329,33 @@ run and makes repeated idempotency checks faster.
 ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
 ```
 
-**TODO:** paste the second-run PLAY RECAP showing `changed=0`.
+```text
+PLAY [Deploy QuickNotes to the Lab 5 VM] ***************************************
+
+TASK [Create the quicknotes system group] **************************************
+ok: [quicknotes-vm]
+
+TASK [Create the quicknotes system user] ***************************************
+ok: [quicknotes-vm]
+
+TASK [Ensure the quicknotes data directory exists] *****************************
+ok: [quicknotes-vm]
+
+TASK [Install the QuickNotes binary] *******************************************
+ok: [quicknotes-vm]
+
+TASK [Install the systemd unit] ************************************************
+ok: [quicknotes-vm]
+
+TASK [Reload systemd when the unit changes] ************************************
+skipping: [quicknotes-vm]
+
+TASK [Enable and start the quicknotes service] *********************************
+ok: [quicknotes-vm]
+
+PLAY RECAP *********************************************************************
+quicknotes-vm              : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+```
 
 ### Selective change: template only + handler fired
 
@@ -280,7 +370,36 @@ Expected behavior:
 - The restart handler is invoked
 - The `user`, `file`, and `copy` tasks stay `ok`
 
-**TODO:** paste the PLAY RECAP and the handler output.
+```text
+PLAY [Deploy QuickNotes to the Lab 5 VM] ***************************************
+
+TASK [Create the quicknotes system group] **************************************
+ok: [quicknotes-vm]
+
+TASK [Create the quicknotes system user] ***************************************
+ok: [quicknotes-vm]
+
+TASK [Ensure the quicknotes data directory exists] *****************************
+ok: [quicknotes-vm]
+
+TASK [Install the QuickNotes binary] *******************************************
+ok: [quicknotes-vm]
+
+TASK [Install the systemd unit] ************************************************
+changed: [quicknotes-vm]
+
+TASK [Reload systemd when the unit changes] ************************************
+ok: [quicknotes-vm]
+
+TASK [Enable and start the quicknotes service] *********************************
+ok: [quicknotes-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes-vm]
+
+PLAY RECAP *********************************************************************
+quicknotes-vm              : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
 
 ### Preview a third change with `--check --diff`
 
@@ -289,7 +408,21 @@ ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml \
   -e quicknotes_data_path=/var/lib/quicknotes/notes-v2.json --check --diff
 ```
 
-**TODO:** paste one useful diff excerpt.
+```diff
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /Users/arsenypinigin/.ansible/tmp/ansible-local-12275b4sv3mqt/tmpy1vbafoo/quicknotes.service.j2
+@@ -8,8 +8,8 @@
+ User=quicknotes
+ Group=quicknotes
+ WorkingDirectory=/var/lib/quicknotes
+-Environment=ADDR=:9090
+-Environment=DATA_PATH=/var/lib/quicknotes/notes.json
++Environment=ADDR=:8080
++Environment=DATA_PATH=/var/lib/quicknotes/notes-v2.json
+ Environment=SEED_PATH=/opt/quicknotes/app/seed.json
+ ExecStart=/usr/local/bin/quicknotes
+ Restart=on-failure
+```
 
 ### Design questions
 

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -13,13 +13,14 @@ service lifecycle through handlers.
 | Host OS | macOS (authoring machine) |
 | Git branch | `feature/lab7` |
 | VM target | Lab 5 Vagrant VM (`127.0.0.1:18080 -> guest:8080`) |
-| App artifact | `ansible/files/quicknotes` |
+| App artifact | `ansible/files/quicknotes` (Linux arm64 for this MacBook VM path) |
 | Ansible layout | `ansible/` |
 
-> Note: this repository snapshot did not have `ansible` or `vagrant` installed,
-> so the playbook, inventory, and submission were prepared statically and the
-> Linux binary was built locally. The command outputs marked **TODO** below must
-> be collected on a machine that has the Lab 5 VM and Ansible available.
+> Note: this repository snapshot initially did not have `ansible` or `vagrant`
+> installed, so the playbook and submission were prepared first and the live VM
+> verification still depends on finishing the local VM-tool install. The command
+> outputs marked **TODO** below must be collected once the Lab 5 VM is running
+> on this MacBook.
 
 ## Implementation summary
 
@@ -180,10 +181,11 @@ WantedBy=multi-user.target
 
 ## Static artifact build
 
-The managed binary was produced from `app/` as a static Linux executable:
+The managed binary was produced from `app/` as a static Linux executable for
+the Apple Silicon VM path:
 
 ```bash
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
   go build -C app -trimpath -ldflags='-s -w' \
   -o ../ansible/files/quicknotes .
 ```
@@ -320,6 +322,8 @@ obvious.
 
 - The inventory assumes the standard Vagrant VM created from the repo root with
   the Lab 5 `Vagrantfile` now restored into this branch.
+- The Lab 5 `Vagrantfile` was updated to choose the correct guest Go tarball
+  for either `amd64` or `arm64`, because this MacBook is Apple Silicon.
 - The binary is committed intentionally because the lab specification requires an
   `ansible/files/quicknotes` payload that the playbook ships to the VM.
 - The Lab 7 bonus (`ansible-pull` + systemd timer) was not implemented in this

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,326 @@
+# Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
+
+## Objective
+
+Write an idempotent Ansible playbook that deploys the QuickNotes binary to the
+Lab 5 Vagrant VM, installs a parameterized systemd unit, and manages the
+service lifecycle through handlers.
+
+## Environment
+
+| Component | Version / value |
+|-----------|-----------------|
+| Host OS | macOS (authoring machine) |
+| Git branch | `feature/lab7` |
+| VM target | Lab 5 Vagrant VM (`127.0.0.1:18080 -> guest:8080`) |
+| App artifact | `ansible/files/quicknotes` |
+| Ansible layout | `ansible/` |
+
+> Note: this repository snapshot did not have `ansible` or `vagrant` installed,
+> so the playbook, inventory, and submission were prepared statically and the
+> Linux binary was built locally. The command outputs marked **TODO** below must
+> be collected on a machine that has the Lab 5 VM and Ansible available.
+
+## Implementation summary
+
+The `ansible/` directory contains:
+
+1. `inventory.ini` targeting the Lab 5 VM over the Vagrant SSH endpoint.
+2. `playbook.yaml` with `become: true` and `gather_facts: false`.
+3. `files/quicknotes`, a static Linux QuickNotes binary built from `app/`.
+4. `templates/quicknotes.service.j2`, a Jinja2 systemd unit whose runtime
+   values come from playbook variables.
+
+The playbook performs the required idempotent steps:
+
+1. Creates the `quicknotes` system group and system user, with
+   `create_home: false` and a non-login shell.
+2. Ensures `/var/lib/quicknotes` exists with owner `quicknotes:quicknotes` and
+   mode `0750`.
+3. Copies the binary to `/usr/local/bin/quicknotes` with mode `0755`.
+4. Renders `/etc/systemd/system/quicknotes.service` from a template.
+5. Reloads systemd only when the rendered unit changed, then enables and starts
+   the service.
+6. Restarts the service only when the binary or unit file changes, via a
+   handler.
+
+`gather_facts` is disabled intentionally because this playbook does not branch
+on OS facts, CPU architecture, or package manager state; skipping the setup step
+keeps runs shorter and makes the idempotency proof tighter.
+
+## Repository layout
+
+```text
+ansible/
+├── inventory.ini
+├── playbook.yaml
+├── files/
+│   └── quicknotes
+└── templates/
+    └── quicknotes.service.j2
+```
+
+## The playbook
+
+```yaml
+- name: Deploy QuickNotes to the Lab 5 VM
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_group: quicknotes
+    quicknotes_home: /nonexistent
+    quicknotes_shell: /usr/sbin/nologin
+    quicknotes_binary_src: files/quicknotes
+    quicknotes_binary_dest: /usr/local/bin/quicknotes
+    quicknotes_service_name: quicknotes
+    quicknotes_service_unit_path: /etc/systemd/system/quicknotes.service
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_data_path: /var/lib/quicknotes/notes.json
+    quicknotes_seed_path: /opt/quicknotes/app/seed.json
+    listen_addr: ":8080"
+
+  tasks:
+    - name: Create the quicknotes system group
+      ansible.builtin.group:
+        name: "{{ quicknotes_group }}"
+        system: true
+
+    - name: Create the quicknotes system user
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        system: true
+        create_home: false
+        home: "{{ quicknotes_home }}"
+        shell: "{{ quicknotes_shell }}"
+
+    - name: Ensure the quicknotes data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        mode: "0750"
+
+    - name: Install the QuickNotes binary
+      ansible.builtin.copy:
+        src: "{{ quicknotes_binary_src }}"
+        dest: "{{ quicknotes_binary_dest }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Install the systemd unit
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: "{{ quicknotes_service_unit_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: quicknotes_service_unit
+      notify: restart quicknotes
+
+    - name: Reload systemd when the unit changes
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when: quicknotes_service_unit.changed
+
+    - name: Enable and start the quicknotes service
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        enabled: true
+        state: started
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        state: restarted
+        daemon_reload: true
+```
+
+## Inventory
+
+```ini
+[quicknotes_vm]
+quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3
+```
+
+If `vagrant ssh-config` prints a different forwarded port or key path on your
+machine, update `ansible_port` and `ansible_ssh_private_key_file` to match that
+output before running the playbook.
+
+## Systemd unit template
+
+```ini
+[Unit]
+Description=QuickNotes API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ quicknotes_user }}
+Group={{ quicknotes_group }}
+WorkingDirectory={{ quicknotes_data_dir }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ quicknotes_data_path }}
+Environment=SEED_PATH={{ quicknotes_seed_path }}
+ExecStart={{ quicknotes_binary_dest }}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Static artifact build
+
+The managed binary was produced from `app/` as a static Linux executable:
+
+```bash
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+  go build -C app -trimpath -ldflags='-s -w' \
+  -o ../ansible/files/quicknotes .
+```
+
+## Task 1 — Run + verify
+
+### Dry-run
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check
+```
+
+**TODO:** paste the output.
+
+### First real run
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+```
+
+**TODO:** paste the full PLAY RECAP from the first run.
+
+### Reachability proof
+
+```bash
+curl -s http://localhost:18080/health
+```
+
+**TODO:** paste the output proving the service is reachable through the Vagrant
+port-forward.
+
+### Design questions
+
+**a) `command:` vs dedicated modules.**
+Dedicated modules such as `user`, `file`, `copy`, `template`, and `systemd`
+understand the desired end state and compare it with the target's current
+state. That makes them idempotent: if the target already matches, they return
+`ok` instead of changing anything. `command:` and `shell:` just run imperative
+commands; Ansible cannot reliably infer whether they changed state, so they are
+usually reported as changed every run unless you add fragile guards like
+`creates:` or `changed_when:`. For this lab, idempotency matters because the
+second run must prove `changed=0` and the restart handler must fire only when an
+actual config or binary change occurred.
+
+**b) `notify:` and handlers.**
+A handler fires only when a task that references it reports `changed`. If the
+`copy` or `template` task determines that the destination file already matches
+what Ansible would write, the task stays `ok` and the handler does not run. That
+is the right default because unnecessary restarts create avoidable downtime and
+noise; service restarts should be coupled to real state changes, not to the mere
+fact that a playbook was executed.
+
+**c) Variable hierarchy.**
+For this lab I would use three levels:
+1. Playbook vars for repo-local defaults such as `listen_addr`,
+   `quicknotes_data_path`, and `quicknotes_seed_path`, because they document the
+   intended baseline close to the tasks.
+2. Inventory or `group_vars/quicknotes_vm` for environment-specific connection
+   values such as `ansible_host`, `ansible_port`, and `ansible_user`, because
+   they belong to the target environment rather than the app logic.
+3. Extra vars (`-e`) only for one-off overrides during demonstrations, such as
+   `-e listen_addr=:9090` to prove selective template changes, because CLI vars
+   have high precedence and are ideal for temporary experiments without editing
+   committed files.
+
+**d) Do we need `gather_facts: true` here?**
+No. This playbook does not make decisions based on Ansible facts; it copies a
+binary, writes a template, and manages a service on a known Ubuntu VM. Turning
+fact gathering off skips the setup phase, which usually saves a few seconds per
+run and makes repeated idempotency checks faster.
+
+## Task 2 — Idempotency + selective re-run
+
+### Second run: prove `changed=0`
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml
+```
+
+**TODO:** paste the second-run PLAY RECAP showing `changed=0`.
+
+### Selective change: template only + handler fired
+
+One simple way to prove selective change without editing committed files is:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml -e listen_addr=:9090
+```
+
+Expected behavior:
+- The `template` task reports `changed=1`
+- The restart handler is invoked
+- The `user`, `file`, and `copy` tasks stay `ok`
+
+**TODO:** paste the PLAY RECAP and the handler output.
+
+### Preview a third change with `--check --diff`
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml \
+  -e quicknotes_data_path=/var/lib/quicknotes/notes-v2.json --check --diff
+```
+
+**TODO:** paste one useful diff excerpt.
+
+### Design questions
+
+**e) Why does the second run report `changed=0`?**
+Because Ansible modules compare the current remote state to the desired state.
+`file` checks attributes such as existence, type, owner, group, and mode.
+`copy` checks the destination file contents plus metadata. `template` renders the
+Jinja2 template and compares the rendered bytes to the target file before
+rewriting it. If nothing differs, the tasks are already converged and the play
+reports `ok` rather than `changed`.
+
+**f) What would happen with `shell: 'echo "ADDR=..." > /etc/systemd/system/quicknotes.service'`?**
+You would lose safe change detection, structured templating, and predictable file
+metadata management. The shell task would typically report changed every run,
+which would restart the service every run even when the unit content was
+identical. It also makes quoting brittle, hides accidental truncation bugs,
+cannot easily manage owner/mode consistently, and encourages partially written
+or malformed units when variables contain spaces or special characters. In
+short: more imperative code, weaker idempotency, and noisier deploys.
+
+**g) What bug does `--check --diff` catch that plain `--check` can miss?**
+Plain `--check` tells you that a template *would* change, but not whether the
+rendered result is sensible. `--diff` exposes the exact before/after lines, so
+it catches bugs like accidentally changing `ADDR=:8080` to `ADDR=8080`, pointing
+`SEED_PATH` at the wrong file, or rendering a typo into `ExecStart`. Those are
+production-impacting config mistakes that a dry-run count alone would not make
+obvious.
+
+## Notes
+
+- The inventory assumes the standard Vagrant VM created from the repo root with
+  the Lab 5 `Vagrantfile` now restored into this branch.
+- The binary is committed intentionally because the lab specification requires an
+  `ansible/files/quicknotes` payload that the playbook ships to the VM.
+- The Lab 7 bonus (`ansible-pull` + systemd timer) was not implemented in this
+  branch because it needs a reachable Git clone URL and live VM verification.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -16,11 +16,11 @@ service lifecycle through handlers.
 | App artifact | `ansible/files/quicknotes` (Linux arm64 for this MacBook VM path) |
 | Ansible layout | `ansible/` |
 
-> Note: this repository snapshot initially did not have `ansible` or `vagrant`
-> installed, so the playbook and submission were prepared first and the live VM
-> verification still depends on finishing the local VM-tool install. The command
-> outputs marked **TODO** below must be collected once the Lab 5 VM is running
-> on this MacBook.
+> Note: this lab was completed on an Apple Silicon MacBook, so two small
+> compatibility adjustments were required compared with the original Lab 5/7
+> assumptions: the Lab 5 `Vagrantfile` now picks the guest Go tarball by
+> architecture, and the committed QuickNotes payload in `ansible/files/` was
+> rebuilt for Linux arm64.
 
 ## Implementation summary
 
@@ -31,6 +31,8 @@ The `ansible/` directory contains:
 3. `files/quicknotes`, a static Linux QuickNotes binary built from `app/`.
 4. `templates/quicknotes.service.j2`, a Jinja2 systemd unit whose runtime
    values come from playbook variables.
+5. Bonus templates for `ansible-pull`: a local inventory plus systemd service
+   and timer units.
 
 The playbook performs the required idempotent steps:
 
@@ -63,6 +65,9 @@ ansible/
 ├── files/
 │   └── quicknotes
 └── templates/
+    ├── ansible-pull-quicknotes.service.j2
+    ├── ansible-pull-quicknotes.timer.j2
+    ├── quicknotes-local.ini.j2
     └── quicknotes.service.j2
 ```
 
@@ -87,6 +92,15 @@ ansible/
     quicknotes_data_path: /var/lib/quicknotes/notes.json
     quicknotes_seed_path: /opt/quicknotes/app/seed.json
     listen_addr: ":8080"
+    quicknotes_restart_sec: 4
+    ansible_pull_enabled: true
+    ansible_pull_repo_url: https://github.com/Hidancloud/DevOps-Intro.git
+    ansible_pull_repo_branch: feature/lab7
+    ansible_pull_checkout_dir: /var/lib/ansible-pull/quicknotes
+    ansible_pull_inventory_path: /etc/ansible/quicknotes-local.ini
+    ansible_pull_playbook_path: ansible/playbook.yaml
+    ansible_pull_service_name: ansible-pull-quicknotes.service
+    ansible_pull_timer_name: ansible-pull-quicknotes.timer
 
   tasks:
     - name: Create the quicknotes system group
@@ -141,6 +155,87 @@ ansible/
         enabled: true
         state: started
 
+    - name: Install ansible-pull dependencies
+      ansible.builtin.apt:
+        name:
+          - ansible
+          - git
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_pull_enabled
+
+    - name: Ensure ansible config directory exists
+      ansible.builtin.file:
+        path: /etc/ansible
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull local inventory
+      ansible.builtin.template:
+        src: templates/quicknotes-local.ini.j2
+        dest: "{{ ansible_pull_inventory_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: ansible_pull_local_inventory
+      when: ansible_pull_enabled
+
+    - name: Ensure ansible-pull checkout directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_pull_checkout_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull service
+      ansible.builtin.template:
+        src: templates/ansible-pull-quicknotes.service.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_service_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: ansible_pull_service_unit
+      when: ansible_pull_enabled
+
+    - name: Install ansible-pull timer
+      ansible.builtin.template:
+        src: templates/ansible-pull-quicknotes.timer.j2
+        dest: "/etc/systemd/system/{{ ansible_pull_timer_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: ansible_pull_timer_unit
+      when: ansible_pull_enabled
+
+    - name: Reload systemd when ansible-pull units change
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when:
+        - ansible_pull_enabled
+        - ansible_pull_service_unit.changed or ansible_pull_timer_unit.changed
+
+    - name: Prime ansible-pull once so the timer has a last-run anchor
+      ansible.builtin.systemd:
+        name: "{{ ansible_pull_service_name }}"
+        state: started
+      when:
+        - ansible_pull_enabled
+        - ansible_connection != 'local'
+        - ansible_pull_local_inventory.changed or ansible_pull_service_unit.changed or ansible_pull_timer_unit.changed
+
+    - name: Enable and start the ansible-pull timer
+      ansible.builtin.systemd:
+        name: "{{ ansible_pull_timer_name }}"
+        enabled: true
+        state: started
+      when: ansible_pull_enabled
+
   handlers:
     - name: restart quicknotes
       ansible.builtin.systemd:
@@ -153,7 +248,7 @@ ansible/
 
 ```ini
 [quicknotes_vm]
-quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3
+quicknotes-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa'
 ```
 
 If `vagrant ssh-config` prints a different forwarded port or key path on your
@@ -178,7 +273,7 @@ Environment=DATA_PATH={{ quicknotes_data_path }}
 Environment=SEED_PATH={{ quicknotes_seed_path }}
 ExecStart={{ quicknotes_binary_dest }}
 Restart=on-failure
-RestartSec=3
+RestartSec={{ quicknotes_restart_sec }}
 
 [Install]
 WantedBy=multi-user.target
@@ -196,6 +291,11 @@ GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
 ```
 
 ## Task 1 — Run + verify
+
+The Task 1 dry-run and first real-run evidence below was captured before the
+bonus `ansible-pull` block was appended to the playbook. The later Task 2
+idempotency proof and Bonus section show that the final extended playbook still
+converges cleanly on the same VM.
 
 ### Dry-run
 
@@ -353,8 +453,35 @@ skipping: [quicknotes-vm]
 TASK [Enable and start the quicknotes service] *********************************
 ok: [quicknotes-vm]
 
+TASK [Install ansible-pull dependencies] ***************************************
+ok: [quicknotes-vm]
+
+TASK [Ensure ansible config directory exists] **********************************
+ok: [quicknotes-vm]
+
+TASK [Install ansible-pull local inventory] ************************************
+ok: [quicknotes-vm]
+
+TASK [Ensure ansible-pull checkout directory exists] ***************************
+ok: [quicknotes-vm]
+
+TASK [Install ansible-pull service] ********************************************
+ok: [quicknotes-vm]
+
+TASK [Install ansible-pull timer] **********************************************
+ok: [quicknotes-vm]
+
+TASK [Reload systemd when ansible-pull units change] ***************************
+skipping: [quicknotes-vm]
+
+TASK [Prime ansible-pull once so the timer has a last-run anchor] **************
+skipping: [quicknotes-vm]
+
+TASK [Enable and start the ansible-pull timer] *********************************
+ok: [quicknotes-vm]
+
 PLAY RECAP *********************************************************************
-quicknotes-vm              : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
+quicknotes-vm              : ok=13   changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0
 ```
 
 ### Selective change: template only + handler fired
@@ -451,6 +578,107 @@ it catches bugs like accidentally changing `ADDR=:8080` to `ADDR=8080`, pointing
 production-impacting config mistakes that a dry-run count alone would not make
 obvious.
 
+## Bonus Task — `ansible-pull` GitOps loop
+
+### Implementation
+
+The bonus adds three VM-local artifacts:
+
+1. `/etc/ansible/quicknotes-local.ini`
+2. `/etc/systemd/system/ansible-pull-quicknotes.service`
+3. `/etc/systemd/system/ansible-pull-quicknotes.timer`
+
+The local inventory targets the VM itself via `ansible_connection=local`, so
+the same `ansible/playbook.yaml` can run either from the host or from inside
+the VM. The systemd service executes:
+
+```bash
+/usr/bin/ansible-pull \
+  -U https://github.com/Hidancloud/DevOps-Intro.git \
+  -C feature/lab7 \
+  -d /var/lib/ansible-pull/quicknotes \
+  -i /etc/ansible/quicknotes-local.ini \
+  ansible/playbook.yaml
+```
+
+The timer uses the required cadence:
+
+```ini
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit=ansible-pull-quicknotes.service
+```
+
+### Timer proof
+
+`systemctl list-timers` on the VM:
+
+```text
+Tue 2026-06-30 14:14:56 UTC 4min 44s Tue 2026-06-30 14:09:56 UTC   15s ago ansible-pull-quicknotes.timer ansible-pull-quicknotes.service
+```
+
+The local inventory installed in the VM:
+
+```ini
+[quicknotes_vm]
+quicknotes-vm ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+```
+
+### Convergence demonstration
+
+To produce a non-destructive but visible reconcile, I changed the playbook
+variable `quicknotes_restart_sec` from `3` to `4`, committed it to
+`feature/lab7`, and pushed to GitHub.
+
+Timeline:
+
+| Event | Time |
+|-------|------|
+| Git commit pushed (`5b92184`) | `2026-06-30T17:05:27+03:00` |
+| Next timer fire on VM | `2026-06-30 14:09:56 UTC` |
+| State observed reconciled | `2026-06-30 14:10:11 UTC` |
+
+State proof from the VM after the timer-fired run:
+
+```text
+16:RestartSec=4
+```
+
+Relevant `journalctl` excerpt:
+
+```text
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: RUNNING HANDLER [restart quicknotes] *******************************************
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: changed: [quicknotes-vm]
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: PLAY RECAP *********************************************************************
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: quicknotes-vm              : ok=15   changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: Starting Ansible Pull at 2026-06-30 14:09:56
+Jun 30 14:10:06 quicknotes-vm ansible-pull[8484]: /usr/bin/ansible-pull -U https://github.com/Hidancloud/DevOps-Intro.git -C feature/lab7 -d /var/lib/ansible-pull/quicknotes -i /etc/ansible/quicknotes-local.ini ansible/playbook.yaml
+```
+
+QuickNotes remained healthy after reconciliation:
+
+```text
+{"notes":4,"status":"ok"}
+```
+
+### Design questions
+
+**h) What is the security benefit of `ansible-pull` vs push mode?**
+In pull mode, the VM does not need to accept inbound SSH from a central control
+node during each deploy. That shrinks the attack surface: no long-lived inbound
+management path needs to stay open, and compromise of the control node does not
+automatically grant shell access into every managed host. The node only needs
+outbound access to fetch Git, then it reconciles locally.
+
+**i) What is the Kubernetes-layer equivalent, and why is this a fair simulator?**
+The same pattern at the Kubernetes layer is commonly associated with **Argo CD**
+or **Flux**: Git is the source of truth, and an in-cluster agent pulls desired
+state and reconciles the live system to match. `ansible-pull` is a fair VM-layer
+simulator because the control loop is the same even though the resource model is
+different: commit to Git, agent detects new desired state, apply drift-correcting
+changes locally, and repeat on a schedule.
+
 ## Notes
 
 - The inventory assumes the standard Vagrant VM created from the repo root with
@@ -459,5 +687,3 @@ obvious.
   for either `amd64` or `arm64`, because this MacBook is Apple Silicon.
 - The binary is committed intentionally because the lab specification requires an
   `ansible/files/quicknotes` payload that the playbook ships to the VM.
-- The Lab 7 bonus (`ansible-pull` + systemd timer) was not implemented in this
-  branch because it needs a reachable Git clone URL and live VM verification.


### PR DESCRIPTION
## Goal
Deploy QuickNotes to the Lab 5 Vagrant VM with an idempotent Ansible playbook, and add the bonus `ansible-pull` GitOps timer.

## Changes
- Added the Ansible deployment layout under `ansible/`:
  - `inventory.ini`
  - `playbook.yaml`
  - `templates/quicknotes.service.j2`
  - `templates/quicknotes-local.ini.j2`
  - `templates/ansible-pull-quicknotes.service.j2`
  - `templates/ansible-pull-quicknotes.timer.j2`
- Added the QuickNotes deployment artifact at `ansible/files/quicknotes`
- Implemented idempotent playbook steps to:
  - create the `quicknotes` system user and group
  - create `/var/lib/quicknotes`
  - install `/usr/local/bin/quicknotes`
  - template `/etc/systemd/system/quicknotes.service`
  - enable and start the service
  - restart only on real changes via handlers
- Added the bonus `ansible-pull` setup:
  - local inventory on the VM
  - systemd service for `ansible-pull`
  - systemd timer running every 5 minutes
- Updated the Lab 5 `Vagrantfile` for Apple Silicon compatibility
- Documented implementation, verification, idempotency proof, and bonus evidence in `submissions/lab7.md`

## Testing
- Ran `vagrant up`
- Verified SSH settings with `vagrant ssh-config`
- Ran the playbook against the VM with Ansible
- Ran the playbook a second time to prove idempotency
- Verified QuickNotes health through the forwarded port
- Verified `ansible-pull` timer activation and convergence for the bonus task
- Recorded all evidence and answers in `submissions/lab7.md`

## Checklist
- [x] Title is a clear sentence (<= 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/labN.md` updated