### PR TITLE
Complete Lab 7 with idempotent Ansible deploy and ansible-pull

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,17 @@
 ## Goal
-<!-- What does this PR accomplish? 1 sentence. -->
+Complete Lab 5 by adding a reproducible Vagrant setup for QuickNotes and documenting Task 1, Task 2, and the bonus VM-vs-container benchmark.
 
 ## Changes
-- 
+- Task 1: Added a root `Vagrantfile` for Ubuntu 24.04, VirtualBox resource limits, localhost-only port forwarding, synced `app/`, and pinned Go 1.24.5 provisioning.
+- Task 2: Documented the snapshot save, break, restore, and recovery workflow in `submissions/lab5.md`.
+- Bonus: Added the VM vs Docker resource baseline, comparison table, and measured results in `submissions/lab5.md`.
 
 ## Testing
-<!-- How did you verify it? -->
+- Task 1: Validated the Vagrant setup, tested the Go app, and checked QuickNotes from both the VM and the host.
+- Task 2: Saved a snapshot, deliberately broke the Go install, restored the VM, and verified recovery.
+- Bonus: Measured VM boot time, RAM, process count, and disk usage, then compared them with the same metrics for a Docker container.
 
 ## Checklist
 - [ ] Title is a clear sentence (≤ 70 chars)
-- [ ] Commits are signed (`git log --show-signature`)
-- [ ] `submissions/labN.md` updated
+- [x] Commits are signed (`git log --show-signature`)
+- [x] `submissions/lab5.md` updated

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,69 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.box_version = "202510.26.0"
+  config.vm.box_check_update = false
+  config.vm.hostname = "quicknotes-lab5"
+
+  config.vm.network "forwarded_port",
+    guest: 8080,
+    host: 18080,
+    host_ip: "127.0.0.1"
+
+  config.vm.synced_folder "./app", "/home/vagrant/app", type: "virtualbox"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "quicknotes-lab5"
+    vb.cpus = 2
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell", privileged: true, inline: <<-'SHELL'
+    set -euxo pipefail
+
+    GO_VERSION="1.24.5"
+    GO_ROOT="/usr/local/go"
+
+    apt-get update
+    apt-get install -y ca-certificates curl tar
+
+    guest_arch="$(dpkg --print-architecture)"
+    case "$guest_arch" in
+      amd64)
+        go_arch="amd64"
+        go_sha256="10ad9e86233e74c0f6590fe5426895de6bf388964210eac34a6d83f38918ecdc"
+        ;;
+      arm64)
+        go_arch="arm64"
+        go_sha256="0df02e6aeb3d3c06c95ff201d575907c736d6c62cfa4b6934c11203f1d600ffa"
+        ;;
+      *)
+        echo "Unsupported guest architecture: $guest_arch" >&2
+        exit 1
+        ;;
+    esac
+
+    archive="go${GO_VERSION}.linux-${go_arch}.tar.gz"
+    url="https://go.dev/dl/${archive}"
+    tmp_archive="/tmp/${archive}"
+
+    installed_version=""
+    if [ -x "${GO_ROOT}/bin/go" ]; then
+      installed_version="$(${GO_ROOT}/bin/go version | awk '{print $3}')"
+    fi
+
+    if [ "$installed_version" != "go${GO_VERSION}" ]; then
+      rm -rf "${GO_ROOT}"
+      curl -fsSL "${url}" -o "${tmp_archive}"
+      echo "${go_sha256}  ${tmp_archive}" | sha256sum --check --status
+      tar -C /usr/local -xzf "${tmp_archive}"
+      rm -f "${tmp_archive}"
+    fi
+
+    ln -sf "${GO_ROOT}/bin/go" /usr/local/bin/go
+    ln -sf "${GO_ROOT}/bin/gofmt" /usr/local/bin/gofmt
+
+    cat >/etc/profile.d/go.sh <<'EOF'
+export PATH=/usr/local/go/bin:$PATH
+EOF
+  SHELL
+end

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,2 @@
+[quicknotes_vm]
+lab5-vm ansible_host=127.0.0.1 ansible_port=2222 ansible_user=vagrant ansible_ssh_private_key_file=/Users/axxil/Study/Innopolis/DevOps-Intro/.vagrant/machines/default/virtualbox/private_key ansible_python_interpreter=/usr/bin/python3 ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -15,9 +15,20 @@
     quicknotes_seed_src: ../app/seed.json
     quicknotes_seed_path: /var/lib/quicknotes/seed.json
     quicknotes_listen_addr: ":8080"
-    quicknotes_restart_sec: 3s
+    quicknotes_restart_sec: 4s
     quicknotes_service_name: quicknotes
     quicknotes_service_path: /etc/systemd/system/quicknotes.service
+    quicknotes_pull_packages:
+      - ansible
+      - git
+    quicknotes_pull_repo_url: https://github.com/smairon/DevOps-Intro.git
+    quicknotes_pull_repo_branch: feature/lab7
+    quicknotes_pull_checkout_dir: /opt/quicknotes-ansible-pull
+    quicknotes_pull_inventory_path: /etc/ansible/quicknotes-local.ini
+    quicknotes_pull_service_name: quicknotes-ansible-pull.service
+    quicknotes_pull_timer_name: quicknotes-ansible-pull.timer
+    quicknotes_pull_service_path: /etc/systemd/system/quicknotes-ansible-pull.service
+    quicknotes_pull_timer_path: /etc/systemd/system/quicknotes-ansible-pull.timer
 
   tasks:
     - name: Create quicknotes system user
@@ -53,6 +64,52 @@
         group: "{{ quicknotes_group }}"
         mode: "0640"
 
+    - name: Install ansible-pull dependencies
+      ansible.builtin.apt:
+        name: "{{ quicknotes_pull_packages }}"
+        state: present
+        update_cache: true
+
+    - name: Ensure ansible-pull checkout directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_pull_checkout_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Ensure ansible configuration directory exists
+      ansible.builtin.file:
+        path: /etc/ansible
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Install ansible-pull local inventory
+      ansible.builtin.template:
+        src: templates/quicknotes-local.ini.j2
+        dest: "{{ quicknotes_pull_inventory_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Install ansible-pull systemd service
+      ansible.builtin.template:
+        src: templates/quicknotes-ansible-pull.service.j2
+        dest: "{{ quicknotes_pull_service_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Install ansible-pull systemd timer
+      ansible.builtin.template:
+        src: templates/quicknotes-ansible-pull.timer.j2
+        dest: "{{ quicknotes_pull_timer_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+
     - name: Install quicknotes systemd unit
       ansible.builtin.template:
         src: templates/quicknotes.service.j2
@@ -65,6 +122,14 @@
     - name: Enable and start quicknotes service
       ansible.builtin.systemd:
         name: "{{ quicknotes_service_name }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: not ansible_check_mode
+
+    - name: Enable and start ansible-pull timer
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_pull_timer_name }}"
         enabled: true
         state: started
         daemon_reload: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,78 @@
+- name: Deploy QuickNotes to Lab 5 VM
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_group: quicknotes
+    quicknotes_home: /nonexistent
+    quicknotes_shell: /usr/sbin/nologin
+    quicknotes_binary_src: files/quicknotes
+    quicknotes_binary_dest: /usr/local/bin/quicknotes
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_data_path: /var/lib/quicknotes/notes.json
+    quicknotes_seed_src: ../app/seed.json
+    quicknotes_seed_path: /var/lib/quicknotes/seed.json
+    quicknotes_listen_addr: ":8080"
+    quicknotes_service_name: quicknotes
+    quicknotes_service_path: /etc/systemd/system/quicknotes.service
+
+  tasks:
+    - name: Create quicknotes system user
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        system: true
+        create_home: false
+        home: "{{ quicknotes_home }}"
+        shell: "{{ quicknotes_shell }}"
+
+    - name: Ensure quicknotes data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        mode: "0750"
+
+    - name: Install quicknotes binary
+      ansible.builtin.copy:
+        src: "{{ quicknotes_binary_src }}"
+        dest: "{{ quicknotes_binary_dest }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Install quicknotes seed file
+      ansible.builtin.copy:
+        src: "{{ quicknotes_seed_src }}"
+        dest: "{{ quicknotes_seed_path }}"
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_group }}"
+        mode: "0640"
+
+    - name: Install quicknotes systemd unit
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: "{{ quicknotes_service_path }}"
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart quicknotes
+
+    - name: Enable and start quicknotes service
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+      when: not ansible_check_mode
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service_name }}"
+        state: restarted
+        daemon_reload: true
+      when: not ansible_check_mode

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -15,6 +15,7 @@
     quicknotes_seed_src: ../app/seed.json
     quicknotes_seed_path: /var/lib/quicknotes/seed.json
     quicknotes_listen_addr: ":8080"
+    quicknotes_restart_sec: 3s
     quicknotes_service_name: quicknotes
     quicknotes_service_path: /etc/systemd/system/quicknotes.service
 

--- a/ansible/templates/quicknotes-ansible-pull.service.j2
+++ b/ansible/templates/quicknotes-ansible-pull.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=QuickNotes ansible-pull reconciliation
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/ansible-pull -U {{ quicknotes_pull_repo_url }} -C {{ quicknotes_pull_repo_branch }} -d {{ quicknotes_pull_checkout_dir }} -i {{ quicknotes_pull_inventory_path }} ansible/playbook.yaml
+WorkingDirectory={{ quicknotes_pull_checkout_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/quicknotes-ansible-pull.timer.j2
+++ b/ansible/templates/quicknotes-ansible-pull.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run QuickNotes ansible-pull every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit={{ quicknotes_pull_service_name }}
+
+[Install]
+WantedBy=timers.target

--- a/ansible/templates/quicknotes-local.ini.j2
+++ b/ansible/templates/quicknotes-local.ini.j2
@@ -1,0 +1,2 @@
+[quicknotes_vm]
+quicknotes-lab5 ansible_host=127.0.0.1 ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=QuickNotes API service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User={{ quicknotes_user }}
+Group={{ quicknotes_group }}
+WorkingDirectory={{ quicknotes_data_dir }}
+Environment="ADDR={{ quicknotes_listen_addr }}"
+Environment="DATA_PATH={{ quicknotes_data_path }}"
+Environment="SEED_PATH={{ quicknotes_seed_path }}"
+ExecStart={{ quicknotes_binary_dest }}
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -13,7 +13,7 @@ Environment="DATA_PATH={{ quicknotes_data_path }}"
 Environment="SEED_PATH={{ quicknotes_seed_path }}"
 ExecStart={{ quicknotes_binary_dest }}
 Restart=on-failure
-RestartSec=2s
+RestartSec={{ quicknotes_restart_sec }}
 
 [Install]
 WantedBy=multi-user.target

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -130,3 +130,86 @@ I used the `shell` provisioner. For a single VM and one focused task, which is i
 #### d) Why pin `1.24.5` instead of `1.24`
 
 Pinning `1.24.5` makes the environment reproducible because every student gets the exact same compiler build, patches, and behavior. A floating `1.24` reference can silently resolve to different point releases over time, which can change bug fixes, security patches, or module resolution behavior and make results differ between machines or between submission dates.
+
+## Task 2
+
+### Exact commands run
+
+```bash
+vagrant snapshot save task2-go-1-24-5-working
+vagrant ssh -c "sudo rm -rf /usr/local/go /usr/local/bin/go /usr/local/bin/gofmt"
+vagrant ssh -c 'go version'
+time vagrant snapshot restore task2-go-1-24-5-working
+vagrant ssh -c 'go version'
+```
+
+### Snapshot save output
+
+```text
+==> default: Snapshotting the machine as 'task2-go-1-24-5-working'...
+==> default: Snapshot saved! You can restore the snapshot at any time by
+==> default: using `vagrant snapshot restore`. You can delete it using
+==> default: `vagrant snapshot delete`.
+```
+
+### Broken state verification
+
+```text
+bash: line 1: go: command not found
+```
+
+### Restore time output
+
+```text
+==> default: Forcing shutdown of VM...
+==> default: Restoring the snapshot 'task2-go-1-24-5-working'...
+==> default: Resuming suspended VM...
+==> default: Booting VM...
+==> default: Waiting for machine to boot. This may take a few minutes...
+  default: SSH address: 127.0.0.1:2222
+  default: SSH username: vagrant
+  default: SSH auth method: private key
+==> default: Machine booted and ready!
+==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
+==> default: flag to force provisioning. Provisioners marked to run always will still run.
+vagrant snapshot restore task2-go-1-24-5-working  1.31s user 0.76s system 16% cpu 12.770 total
+```
+
+### Recovery verification
+
+```text
+go version go1.24.5 linux/arm64
+```
+
+### Design answers
+
+#### e) Why snapshots are not backups
+
+Snapshots are tied to the same underlying VM disk chain and usually to the same host storage, so they do not protect you from host disk failure, accidental deletion of the VM files, or corruption of the entire VirtualBox VM directory. They are also a poor answer to broader disaster scenarios such as losing the laptop or damaging the base image metadata, because the snapshot disappears with the machine state it depends on.
+
+#### f) Copy-on-write and disk usage
+
+With copy-on-write snapshots, taking a snapshot does not duplicate the entire disk immediately. Instead, each snapshot preserves a point-in-time base and only stores blocks that change afterward. That means 10 snapshots do not cost 10 full VM disks up front, but they still accumulate extra delta files over time, and long-lived or heavily changed VMs can consume substantial disk space.
+
+#### g) When snapshotting becomes an antipattern
+
+Snapshotting becomes an antipattern when you build long chains of snapshots and start depending on them as a workflow instead of keeping environments reproducible from code. Long chains increase storage overhead, slow management operations, make recovery history harder to reason about, and create fragile stateful systems where nobody is sure which snapshot is the real source of truth.
+
+## Bonus Task
+
+### Comparison table
+
+| Dimension | Vagrant VM | Docker container |
+| --- | ---: | ---: |
+| Cold start | 19.662 s | 0.172 s |
+| Idle RAM | 214 MiB used of 824 MiB | 7.77 MiB |
+| On-disk size | 3.3G | 1.32GB |
+| Process count (guest) | 105 | 2 |
+
+### Measurement notes
+
+VM measurements came from `time vagrant up`, `vagrant ssh -c 'free -h'`, `vagrant ssh -c 'ps -A --no-headers | wc -l'`, and `du -sh "$HOME/VirtualBox VMs/quicknotes-lab5"`. Docker measurements came from `docker stop lab5-qn-bonus && time docker start lab5-qn-bonus`, `docker stats --no-stream`, `docker top lab5-qn-bonus`, and `docker images golang:1.24 --format 'IMAGE={{.Repository}}:{{.Tag}} SIZE={{.Size}}'`.
+
+### Analysis
+
+The biggest (but expectable) surprise was the gap in startup latency and background overhead: the container restarted in 0.172 seconds, while the VM took 19.662 seconds to boot, and the container used only 7.77 MiB of RAM versus 214 MiB already consumed inside the guest OS. The VM is the right tool when you need stronger OS-level isolation, a full init/system environment, or realistic testing of machine-level provisioning and configuration management. The container is the right tool for fast, repeatable packaging of a single stateless service where host-kernel sharing is acceptable and startup speed matters. These measurements show why containers dominated the 2014-2020 stateless microservice wave: they are dramatically cheaper to start, smaller to distribute, and lighter to run, so dense scheduling and rapid rollout are much easier than with full virtual machines.

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -1,0 +1,132 @@
+# Lab 5 Submission
+
+## Task 1
+
+### Vagrantfile
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.box_version = "202510.26.0"
+  config.vm.box_check_update = false
+  config.vm.hostname = "quicknotes-lab5"
+
+  config.vm.network "forwarded_port",
+    guest: 8080,
+    host: 18080,
+    host_ip: "127.0.0.1"
+
+  config.vm.synced_folder "./app", "/home/vagrant/app", type: "virtualbox"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "quicknotes-lab5"
+    vb.cpus = 2
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell", privileged: true, inline: <<-'SHELL'
+    set -euxo pipefail
+
+    GO_VERSION="1.24.5"
+    GO_ROOT="/usr/local/go"
+
+    apt-get update
+    apt-get install -y ca-certificates curl tar
+
+    guest_arch="$(dpkg --print-architecture)"
+    case "$guest_arch" in
+      amd64)
+        go_arch="amd64"
+        go_sha256="10ad9e86233e74c0f6590fe5426895de6bf388964210eac34a6d83f38918ecdc"
+        ;;
+      arm64)
+        go_arch="arm64"
+        go_sha256="0df02e6aeb3d3c06c95ff201d575907c736d6c62cfa4b6934c11203f1d600ffa"
+        ;;
+      *)
+        echo "Unsupported guest architecture: $guest_arch" >&2
+        exit 1
+        ;;
+    esac
+
+    archive="go${GO_VERSION}.linux-${go_arch}.tar.gz"
+    url="https://go.dev/dl/${archive}"
+    tmp_archive="/tmp/${archive}"
+
+    installed_version=""
+    if [ -x "${GO_ROOT}/bin/go" ]; then
+      installed_version="$(${GO_ROOT}/bin/go version | awk '{print $3}')"
+    fi
+
+    if [ "$installed_version" != "go${GO_VERSION}" ]; then
+      rm -rf "${GO_ROOT}"
+      curl -fsSL "${url}" -o "${tmp_archive}"
+      echo "${go_sha256}  ${tmp_archive}" | sha256sum --check --status
+      tar -C /usr/local -xzf "${tmp_archive}"
+      rm -f "${tmp_archive}"
+    fi
+
+    ln -sf "${GO_ROOT}/bin/go" /usr/local/bin/go
+    ln -sf "${GO_ROOT}/bin/gofmt" /usr/local/bin/gofmt
+
+    cat >/etc/profile.d/go.sh <<'EOF'
+export PATH=/usr/local/go/bin:$PATH
+EOF
+  SHELL
+end
+```
+
+### First 10 lines of `vagrant up`
+
+```text
+Bringing machine 'default' up with 'virtualbox' provider...
+==> default: Box 'bento/ubuntu-24.04' could not be found. Attempting to find and install...
+  default: Box Provider: virtualbox
+  default: Box Version: 202510.26.0
+==> default: Loading metadata for box 'bento/ubuntu-24.04'
+  default: URL: https://vagrantcloud.com/api/v2/vagrant/bento/ubuntu-24.04
+==> default: Adding box 'bento/ubuntu-24.04' (v202510.26.0) for provider: virtualbox (arm64)
+  default: Downloading: https://vagrantcloud.com/bento/boxes/ubuntu-24.04/versions/202510.26.0/providers/virtualbox/arm64/vagrant.box
+Progress: 0% (Rate: 0*/s, Estimated time remaining: --:--:--)
+Progress: 100% (Rate: 2/s, Estimated time remaining: --:--:--)
+```
+
+### `go version` inside the VM
+
+```text
+go version go1.24.5 linux/arm64
+```
+
+### `curl` output inside the VM
+
+```text
+{"notes":7,"status":"ok"}
+
+HTTP_STATUS=200
+```
+
+### `curl` output from the host via port forwarding
+
+```text
+{"notes":7,"status":"ok"}
+
+HTTP_STATUS=200
+```
+
+### Design answers
+
+#### a) Synced folders
+
+I used the `virtualbox` synced folder type. It is the simplest option here because it works with the VirtualBox provider directly, does not require extra host-side setup, and keeps the `app/` directory mounted live in both directions during development. The trade-off is file system performance: VirtualBox shared folders are usually slower than NFS for heavy I/O workloads, and less predictable than `rsync` for large trees, but for this small Go project they are the most practical choice.
+
+#### b) NAT vs Bridged vs Host-only
+
+I am using Vagrant's default NAT networking mode together with an explicit forwarded port from `127.0.0.1:18080` on the host to `8080` in the guest. Binding the forwarded port to `127.0.0.1` is safer than using a Bridged interface because only processes on the local host can reach the service; the VM does not appear as another machine on the LAN. For a course exercise, that reduces accidental exposure to other devices on the same network and avoids unnecessary attack surface.
+
+#### c) Provisioning choice
+
+I used the `shell` provisioner. For a single VM and one focused task, which is installing a pinned Go toolchain from the upstream tarball, shell is the smallest and most transparent solution. Tools such as Ansible, Puppet, or Chef would also work, but they add extra moving parts and setup cost that are not justified for one short, reproducible bootstrap step.
+
+#### d) Why pin `1.24.5` instead of `1.24`
+
+Pinning `1.24.5` makes the environment reproducible because every student gets the exact same compiler build, patches, and behavior. A floating `1.24` reference can silently resolve to different point releases over time, which can change bug fixes, security patches, or module resolution behavior and make results differ between machines or between submission dates.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,6 +1,6 @@
 # Lab 7 Submission
 
-## Task 1
+## Task 1 — Idempotent Deploy to the Lab 5 VM
 
 ### Ansible files
 
@@ -81,3 +81,135 @@ A handler fires only when a task that references it reports `changed`. If multip
 #### d) gather_facts: true is the default. Do you need it for this playbook? What does turning it off save you per run?
 
 No. This playbook does not branch on the OS family, CPU architecture, network interfaces, package manager facts, or any other discovered host metadata. Turning fact gathering off saves one SSH setup step plus the time to run the `setup` module and transfer the fact payload on every run. For a small one-host playbook, that is not dramatic, but it is still avoidable work and makes the deploy loop tighter.
+
+## Task 2 — Prove Idempotency + Selective Re-run
+
+For the selective-change demonstration I used the playbook variable `quicknotes_restart_sec`, which is rendered into the systemd unit as `RestartSec=...`. That let me trigger a template-only change without moving the service off port `8080`.
+
+### Second run: changed=0
+
+```text
+PLAY [Deploy QuickNotes to Lab 5 VM] *******************************************
+
+TASK [Create quicknotes system user] *******************************************
+ok: [lab5-vm]
+
+TASK [Ensure quicknotes data directory exists] *********************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes binary] ***********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes seed file] ********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes systemd unit] *****************************************
+ok: [lab5-vm]
+
+TASK [Enable and start quicknotes service] *************************************
+ok: [lab5-vm]
+
+PLAY RECAP *********************************************************************
+lab5-vm                    : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### Selective re-run after one variable change
+
+I changed `quicknotes_restart_sec` in [ansible/playbook.yaml](../ansible/playbook.yaml) from `2s` to `3s` and re-ran the playbook.
+
+```text
+PLAY [Deploy QuickNotes to Lab 5 VM] *******************************************
+
+TASK [Create quicknotes system user] *******************************************
+ok: [lab5-vm]
+
+TASK [Ensure quicknotes data directory exists] *********************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes binary] ***********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes seed file] ********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes systemd unit] *****************************************
+changed: [lab5-vm]
+
+TASK [Enable and start quicknotes service] *************************************
+ok: [lab5-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [lab5-vm]
+
+PLAY RECAP *********************************************************************
+lab5-vm                    : ok=7    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+Host-side health check after the restart:
+
+```text
+{"notes":4,"status":"ok"}
+
+HTTP_STATUS=200
+```
+
+### `--check --diff` preview
+
+For the dry-run diff preview, I changed `quicknotes_restart_sec` from `3s` to `4s` locally and ran `ansible-playbook --check --diff`.
+
+```text
+PLAY [Deploy QuickNotes to Lab 5 VM] *******************************************
+
+TASK [Create quicknotes system user] *******************************************
+ok: [lab5-vm]
+
+TASK [Ensure quicknotes data directory exists] *********************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes binary] ***********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes seed file] ********************************************
+ok: [lab5-vm]
+
+TASK [Install quicknotes systemd unit] *****************************************
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /Users/axxil/.ansible/tmp/ansible-local-8786tk_qkp82/tmpk7m4ybfj/quicknotes.service.j2
+@@ -13,7 +13,7 @@
+ Environment="SEED_PATH=/var/lib/quicknotes/seed.json"
+ ExecStart=/usr/local/bin/quicknotes
+ Restart=on-failure
+-RestartSec=3s
++RestartSec=4s
+
+ [Install]
+ WantedBy=multi-user.target
+\ No newline at end of file
+
+changed: [lab5-vm]
+
+TASK [Enable and start quicknotes service] *************************************
+skipping: [lab5-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+skipping: [lab5-vm]
+
+PLAY RECAP *********************************************************************
+lab5-vm                    : ok=5    changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
+```
+
+After capturing the preview, I restored the playbook variable to `3s` so the tracked playbook matches the state that is actually deployed in the VM.
+
+### Design answers
+
+#### e) Why does the second run report changed=0? What specifically does the file / template module check to decide?
+
+The second run reports `changed=0` because every managed object on the VM already matches the desired state declared in the playbook. The `file` module checks the target path's existence and metadata such as type, owner, group, and mode; if `/var/lib/quicknotes` is already a directory owned by `quicknotes:quicknotes` with mode `0750`, there is nothing to do. The `template` module renders the Jinja template on the control side and compares the resulting content against the remote file; if the rendered unit file bytes are identical to `/etc/systemd/system/quicknotes.service`, it returns `ok` instead of `changed`.
+
+#### f) What would happen if you used shell: 'echo "ADDR=..." > /etc/systemd/system/quicknotes.service' instead of the template: module? Trace the failure modes
+
+That would throw away most of the unit file and replace it with a single line, so systemd would no longer have a valid service definition. Even if I used a longer shell redirection to write the whole file, I would still lose the template module's built-in comparison, diff support, quoting safety, ownership/mode management, and predictable newline handling. The shell command would usually report a change every run, which would restart the service every time whether the content actually changed or not. It also makes subtle bugs easier: bad escaping, partial writes, missing permissions, or writing an invalid unit that plain `--check` cannot meaningfully preview.
+
+#### g) ansible-playbook --check is dry-run. --diff shows changes. What's the bug you'd catch by running --check --diff before a production deploy that you'd miss with plain --check?
+
+`--check` alone tells me that a template task would change, but not what the rendered difference is. `--diff` lets me see the exact line-level mutation before I apply it. In this lab, that means I can verify that only `RestartSec=3s` is changing to `RestartSec=4s`. If I had accidentally pointed the wrong variable into the template and changed `ExecStart`, `DATA_PATH`, or `ADDR` at the same time, plain `--check` would still only say `changed`; `--diff` would expose the unintended drift before it hits the VM.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -213,3 +213,73 @@ That would throw away most of the unit file and replace it with a single line, s
 #### g) ansible-playbook --check is dry-run. --diff shows changes. What's the bug you'd catch by running --check --diff before a production deploy that you'd miss with plain --check?
 
 `--check` alone tells me that a template task would change, but not what the rendered difference is. `--diff` lets me see the exact line-level mutation before I apply it. In this lab, that means I can verify that only `RestartSec=3s` is changing to `RestartSec=4s`. If I had accidentally pointed the wrong variable into the template and changed `ExecStart`, `DATA_PATH`, or `ADDR` at the same time, plain `--check` would still only say `changed`; `--diff` would expose the unintended drift before it hits the VM.
+
+## Bonus Task — `ansible-pull` GitOps Loop
+
+### Bonus files
+
+- [ansible/playbook.yaml](../ansible/playbook.yaml)
+- [ansible/templates/quicknotes-local.ini.j2](../ansible/templates/quicknotes-local.ini.j2)
+- [ansible/templates/quicknotes-ansible-pull.service.j2](../ansible/templates/quicknotes-ansible-pull.service.j2)
+- [ansible/templates/quicknotes-ansible-pull.timer.j2](../ansible/templates/quicknotes-ansible-pull.timer.j2)
+
+The bonus extends the same playbook so the Lab 5 VM can reconcile itself from my fork via `ansible-pull` every 5 minutes.
+
+### Timer installation
+
+`systemctl list-timers | grep ansible-pull` after the timer-fired reconciliation:
+
+```text
+Sun 2026-06-28 09:09:45 UTC 3min 31s Sun 2026-06-28 09:04:45 UTC 1min 28s ago quicknotes-ansible-pull.timer quicknotes-ansible-pull.service
+```
+
+### Convergence timeline
+
+1. I pushed commit `16ff83ce448340be2718855c3edfc896e73a482a` on branch `feature/lab7` at `2026-06-28T12:01:24+03:00`.
+2. That commit changed `quicknotes_restart_sec` in [ansible/playbook.yaml](../ansible/playbook.yaml) from `3s` to `4s`, giving the VM a template-backed drift to reconcile.
+3. The VM timer fired at `Sun 2026-06-28 09:04:45 UTC`.
+4. The pull service finished at `Sun 2026-06-28 09:04:56 UTC`.
+5. After the timer-driven run, the VM had pulled the same commit and the deployed unit showed `RestartSec=4s`.
+
+### `ansible-pull` service log excerpt
+
+```text
+Jun 28 09:04:45 quicknotes-lab5 systemd[1]: Starting quicknotes-ansible-pull.service - QuickNotes ansible-pull reconciliation...
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]:     "after": "16ff83ce448340be2718855c3edfc896e73a482a",
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]:     "before": "c5c5f10e32a4fe05626f9daf3758ba7c8580173e",
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: TASK [Install quicknotes systemd unit] *****************************************
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: changed: [127.0.0.1]
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: RUNNING HANDLER [restart quicknotes] *******************************************
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: changed: [127.0.0.1]
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: PLAY RECAP *********************************************************************
+Jun 28 09:04:56 quicknotes-lab5 ansible-pull[7804]: 127.0.0.1                  : ok=14   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+Jun 28 09:04:56 quicknotes-lab5 systemd[1]: Finished quicknotes-ansible-pull.service - QuickNotes ansible-pull reconciliation.
+```
+
+### Reconciled state verification
+
+Inside the VM after the timer fire:
+
+```text
+16ff83ce448340be2718855c3edfc896e73a482a
+RestartSec=4s
+LastTriggerUSec=Sun 2026-06-28 09:04:45 UTC
+```
+
+Host-side health check after the timer-driven reconciliation:
+
+```text
+{"notes":4,"status":"ok"}
+
+HTTP_STATUS=200
+```
+
+### Design answers
+
+#### h) `ansible-pull` is pull mode. What's the security benefit vs the push model where a control node SSHes in?
+
+With `ansible-pull`, the VM makes an outbound connection to fetch desired state instead of exposing an inbound management path from a central control node. That reduces the blast radius of stolen control-node SSH credentials, avoids distributing private SSH access from one orchestrator into every managed machine, and fits stricter firewall models where servers may reach Git over HTTPS but do not accept ad hoc inbound administration from multiple places. The node still needs trust in the repo content, but the trust boundary is narrower than giving a separate control host shell access into the VM.
+
+#### i) What's the same pattern called at the Kubernetes layer, and why is `ansible-pull` a fair simulator at the VM layer?
+
+At the Kubernetes layer this pattern is commonly called GitOps, with tools such as Argo CD or Flux continuously reconciling cluster state from Git. `ansible-pull` is a fair VM-level simulator because the control loop is the same: Git is the source of truth, the target system periodically fetches desired state, compares it to current state, and converges itself without a human pushing imperative changes directly into the node.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,83 @@
+# Lab 7 Submission
+
+## Task 1
+
+### Ansible files
+
+- [ansible/playbook.yaml](../ansible/playbook.yaml)
+- [ansible/inventory.ini](../ansible/inventory.ini)
+- [ansible/templates/quicknotes.service.j2](../ansible/templates/quicknotes.service.j2)
+
+The deployable binary was built on the host for the Lab 5 VM architecture with:
+
+```bash
+cd app/
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o ../ansible/files/quicknotes .
+```
+
+### First run PLAY RECAP
+
+```text
+PLAY [Deploy QuickNotes to Lab 5 VM] *******************************************
+
+TASK [Create quicknotes system user] *******************************************
+changed: [lab5-vm]
+
+TASK [Ensure quicknotes data directory exists] *********************************
+changed: [lab5-vm]
+
+TASK [Install quicknotes binary] ***********************************************
+changed: [lab5-vm]
+
+TASK [Install quicknotes seed file] ********************************************
+changed: [lab5-vm]
+
+TASK [Install quicknotes systemd unit] *****************************************
+changed: [lab5-vm]
+
+TASK [Enable and start quicknotes service] *************************************
+changed: [lab5-vm]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [lab5-vm]
+
+PLAY RECAP *********************************************************************
+lab5-vm                    : ok=7    changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### Service verification
+
+`systemctl` inside the VM:
+
+```text
+enabled
+active
+```
+
+Host-side `curl` through the Vagrant forwarded port:
+
+```text
+{"notes":4,"status":"ok"}
+
+HTTP_STATUS=200
+```
+
+### Design answers
+
+#### a) What's the difference between command: and the dedicated modules (apt, file, copy, systemd)? Which is idempotent, and why does it matter?
+
+`command:` just executes a process with arguments. By itself, it does not know the target state before or after the command, so Ansible usually treats it as a side-effecting action rather than an idempotent declaration. Dedicated modules such as `user`, `file`, `copy`, `template`, and `systemd` encode the desired state and inspect the current state first. For example, `file` checks whether the path already exists with the requested owner, group, mode, and type; `template` compares the rendered content with the remote file; `systemd` checks whether the service is already enabled or started. That matters because idempotent modules let me re-run the playbook safely after partial failure and keep the second run quiet instead of redoing work blindly.
+
+#### b) notify: and handlers: when does a handler fire? When does it not fire? Why is that the right default?
+
+A handler fires only when a task that references it reports `changed`. If multiple tasks notify the same handler in one play, the handler still runs only once at the end of the play. It does not fire when the notifying task is already in the correct state (`ok`), is skipped, or fails before reporting a change. That is the right default because service restarts are disruptive: if neither the binary nor the systemd unit changed, there is no reason to bounce the process.
+
+#### c) Variable hierarchy: Ansible has at least 22 levels of variable precedence. List the top 3 places you'd put a variable for this lab (defaults, group_vars, playbook vars, …) and why
+
+1. Playbook `vars`: this is where I put the stable application defaults for this lab, such as the binary path, data directory, service name, and default listen address, because there is only one target group and one play.
+2. Inventory or `group_vars`: this is where I would put environment-specific values if this lab grew beyond one VM, for example different `listen_addr`, `ansible_port`, or alternate data paths for staging vs production.
+3. Extra vars (`-e`): this is the right place for short-lived overrides during demonstrations or troubleshooting, such as temporarily changing `quicknotes_listen_addr` without editing tracked files.
+
+#### d) gather_facts: true is the default. Do you need it for this playbook? What does turning it off save you per run?
+
+No. This playbook does not branch on the OS family, CPU architecture, network interfaces, package manager facts, or any other discovered host metadata. Turning fact gathering off saves one SSH setup step plus the time to run the `setup` module and transfer the fact payload on every run. For a small one-host playbook, that is not dramatic, but it is still avoidable work and makes the deploy loop tighter.


### PR DESCRIPTION
## Goal
Complete Lab 7 by adding an idempotent Ansible deploy for QuickNotes, proving selective re-runs, and implementing a timer-based ansible-pull GitOps loop.

## Changes
- Added `ansible/inventory.ini` targeting the Lab 5 VM via Vagrant SSH settings.
- Added `ansible/playbook.yaml` to create the `quicknotes` system user, manage `/var/lib/quicknotes`, deploy binary and seed file, render systemd unit from template variables, and restart only on binary/unit changes.
- Added `ansible/templates/quicknotes.service.j2` with variable-driven `ADDR`, `DATA_PATH`, `SEED_PATH`, and restart policy.
- Added bonus GitOps resources: `ansible/templates/quicknotes-local.ini.j2`, `ansible/templates/quicknotes-ansible-pull.service.j2`, and `ansible/templates/quicknotes-ansible-pull.timer.j2`.
- Extended playbook to install `ansible` + `git` in VM and enable/start `quicknotes-ansible-pull.timer` (`OnBootSec=1min`, `OnUnitActiveSec=5min`).
- Updated `submissions/lab7.md` with Task 1 and Task 2 recaps, `--check --diff` evidence, bonus timer output, convergence timeline, and design answers.

## Testing
- Ran `ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check`.
- Ran `ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml` and confirmed service is enabled/active and `curl http://127.0.0.1:18080/health` returns HTTP 200.
- Re-ran playbook without changes and verified `changed=0`.
- Changed one template-backed variable and verified only template task changed and `restart quicknotes` handler fired.
- Ran `ansible-playbook --check --diff` and captured rendered unit diff example.
- Verified bonus timer state with `systemctl list-timers | grep ansible-pull` and confirmed timer-driven reconciliation from pushed commit via `journalctl -u quicknotes-ansible-pull.service`.

## Checklist
- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/lab7.md` updated