### PR TITLE
Lab 7: deploy QuickNotes via Ansible

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Pull Request Template
+
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+
+-
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+GO_VERSION = "1.24.5".freeze
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.hostname = "quicknotes-vm"
+  config.vm.network "forwarded_port", guest: 8080, host: 18080, host_ip: "127.0.0.1"
+  config.vm.synced_folder "./app", "/home/vagrant/app"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name   = "quicknotes-vm"
+    vb.cpus   = 2
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell", env: { "GO_VERSION" => GO_VERSION }, inline: <<-'SHELL'
+    set -euo pipefail
+
+    if command -v go >/dev/null 2>&1 && go version | grep -q "go${GO_VERSION} "; then
+      echo "Go ${GO_VERSION} already installed; skipping."
+      exit 0
+    fi
+
+    echo "Installing Go ${GO_VERSION}..."
+    tarball="go${GO_VERSION}.linux-amd64.tar.gz"
+    curl -fsSLO "https://go.dev/dl/${tarball}"
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf "${tarball}"
+    rm -f "${tarball}"
+
+    echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/go.sh
+    chmod 644 /etc/profile.d/go.sh
+
+    # symlink so non-interactive `vagrant ssh -c 'go ...'` (no /etc/profile.d) finds go
+    ln -sf /usr/local/go/bin/go /usr/local/bin/go
+    ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+    /usr/local/go/bin/go version
+  SHELL
+end

--- a/ansible/files/seed.json
+++ b/ansible/files/seed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome to QuickNotes",
+    "body": "This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 2,
+    "title": "Read app/main.go first",
+    "body": "Start by understanding the entry point — env vars, signal handling, graceful shutdown.",
+    "created_at": "2026-01-15T10:05:00Z"
+  },
+  {
+    "id": 3,
+    "title": "DevOps mantra",
+    "body": "If it hurts, do it more often.",
+    "created_at": "2026-01-15T10:10:00Z"
+  },
+  {
+    "id": 4,
+    "title": "Endpoint cheat-sheet",
+    "body": "GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics",
+    "created_at": "2026-01-15T10:15:00Z"
+  }
+]

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,7 @@
+[quicknotes]
+vm ansible_host=127.0.0.1 ansible_port=2222
+
+[quicknotes:vars]
+ansible_user=vagrant
+ansible_ssh_private_key_file=~/.ssh/quicknotes_vm_key
+ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,63 @@
+---
+- name: Deploy QuickNotes
+  hosts: quicknotes
+  become: true
+  gather_facts: false
+
+  vars:
+    app_user: quicknotes
+    data_dir: /var/lib/quicknotes
+    bin_path: /usr/local/bin/quicknotes
+    listen_addr: ":8080"
+
+  tasks:
+    - name: Create quicknotes system user
+      ansible.builtin.user:
+        name: "{{ app_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
+    - name: Ensure data directory
+      ansible.builtin.file:
+        path: "{{ data_dir }}"
+        state: directory
+        owner: "{{ app_user }}"
+        group: "{{ app_user }}"
+        mode: "0750"
+
+    - name: Copy QuickNotes binary
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ bin_path }}"
+        mode: "0755"
+      notify: Restart quicknotes
+
+    - name: Copy seed file
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ data_dir }}/seed.json"
+        owner: "{{ app_user }}"
+        group: "{{ app_user }}"
+        mode: "0640"
+
+    - name: Render systemd unit
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        mode: "0644"
+      notify: Restart quicknotes
+
+    - name: Enable and start quicknotes
+      ansible.builtin.systemd:
+        name: quicknotes
+        enabled: true
+        state: started
+        daemon_reload: true
+
+  handlers:
+    - name: Restart quicknotes
+      ansible.builtin.systemd:
+        name: quicknotes
+        state: restarted
+        daemon_reload: true

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=QuickNotes service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ app_user }}
+Group={{ app_user }}
+WorkingDirectory={{ data_dir }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ data_dir }}/notes.json
+Environment=SEED_PATH={{ data_dir }}/seed.json
+ExecStart={{ bin_path }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,219 @@
+# Lab 7: Configuration Management: Deploy QuickNotes via Ansible
+
+### `ansible/inventory.ini`
+
+```ini
+[quicknotes]
+vm ansible_host=127.0.0.1 ansible_port=2222
+
+[quicknotes:vars]
+ansible_user=vagrant
+ansible_ssh_private_key_file=~/.ssh/quicknotes_vm_key
+ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa
+```
+
+The Vagrant insecure key was copied into the WSL filesystem and set to mode 600, because keys on the `/mnt/d` Windows mount are world-readable and SSH rejects them. The `+ssh-rsa` options re-enable the box's legacy RSA host and login keys that modern OpenSSH disables by default.
+
+### `ansible/playbook.yaml`
+
+```yaml
+---
+- name: Deploy QuickNotes
+  hosts: quicknotes
+  become: true
+  gather_facts: false
+
+  vars:
+    app_user: quicknotes
+    data_dir: /var/lib/quicknotes
+    bin_path: /usr/local/bin/quicknotes
+    listen_addr: ":8080"
+
+  tasks:
+    - name: Create quicknotes system user
+      ansible.builtin.user:
+        name: "{{ app_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
+    - name: Ensure data directory
+      ansible.builtin.file:
+        path: "{{ data_dir }}"
+        state: directory
+        owner: "{{ app_user }}"
+        group: "{{ app_user }}"
+        mode: "0750"
+
+    - name: Copy QuickNotes binary
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ bin_path }}"
+        mode: "0755"
+      notify: Restart quicknotes
+
+    - name: Copy seed file
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ data_dir }}/seed.json"
+        owner: "{{ app_user }}"
+        group: "{{ app_user }}"
+        mode: "0640"
+
+    - name: Render systemd unit
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        mode: "0644"
+      notify: Restart quicknotes
+
+    - name: Enable and start quicknotes
+      ansible.builtin.systemd:
+        name: quicknotes
+        enabled: true
+        state: started
+        daemon_reload: true
+
+  handlers:
+    - name: Restart quicknotes
+      ansible.builtin.systemd:
+        name: quicknotes
+        state: restarted
+        daemon_reload: true
+```
+
+### `ansible/templates/quicknotes.service.j2`
+
+```jinja
+[Unit]
+Description=QuickNotes service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ app_user }}
+Group={{ app_user }}
+WorkingDirectory={{ data_dir }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ data_dir }}/notes.json
+Environment=SEED_PATH={{ data_dir }}/seed.json
+ExecStart={{ bin_path }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Task 1
+
+```text
+TASK [Create quicknotes system user] *******************************************
+changed: [vm]
+TASK [Ensure data directory] ***************************************************
+changed: [vm]
+TASK [Copy QuickNotes binary] **************************************************
+changed: [vm]
+TASK [Copy seed file] **********************************************************
+changed: [vm]
+TASK [Render systemd unit] *****************************************************
+changed: [vm]
+TASK [Enable and start quicknotes] *********************************************
+changed: [vm]
+RUNNING HANDLER [Restart quicknotes] *******************************************
+changed: [vm]
+
+PLAY RECAP *********************************************************************
+vm  : ok=7    changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### Service reachable via the Vagrant port forward 18080 to 8080
+
+```text
+$ curl -s http://localhost:18080/health
+{"notes":4,"status":"ok"}
+```
+
+### Design questions
+
+**a) `command:` versus the dedicated modules.**
+`command:` and `shell:` just run a string, so Ansible does not know what they do and marks them `changed` every time. The modules check the current state first and act only if something differs. That is what makes re-runs safe and `changed=0` meaningful.
+
+**b) When a handler fires.**
+A handler runs only if a task that notifies it reports `changed`, and it runs once at the end. It is skipped when the task is `ok` or `failed`. So the service restarts only when its files actually changed.
+
+**c) Variable hierarchy, top three places for this lab.**
+
+1. `group_vars/` for per-environment values like `listen_addr`.
+2. Play `vars:`, simple when there is one target (used here).
+3. Role `defaults/`, a fallback if this became a role.
+
+Extra-vars (`-e`) beat all of them and are for one-off overrides.
+
+**d) Is `gather_facts` needed here.**
+No. The playbook uses no facts, only `vars`. Turning it off skips the setup step and saves one round-trip per run.
+
+## Task 2
+
+```text
+PLAY RECAP *********************************************************************
+vm  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### Variable `listen_addr` changed from :8080 to :9090 and only template and handler react
+
+```text
+TASK [Create quicknotes system user] *******************************************
+ok: [vm]
+TASK [Ensure data directory] ***************************************************
+ok: [vm]
+TASK [Copy QuickNotes binary] **************************************************
+ok: [vm]
+TASK [Copy seed file] **********************************************************
+ok: [vm]
+TASK [Render systemd unit] *****************************************************
+changed: [vm]
+TASK [Enable and start quicknotes] *********************************************
+ok: [vm]
+RUNNING HANDLER [Restart quicknotes] *******************************************
+changed: [vm]
+
+PLAY RECAP *********************************************************************
+vm  : ok=7    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### `--check --diff` preview of a third change (`listen_addr` :9090 to :8080)
+
+```text
+TASK [Render systemd unit] *****************************************************
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /home/danielpancake/.ansible/tmp/.../quicknotes.service.j2
+@@ -7,7 +7,7 @@
+ User=quicknotes
+ Group=quicknotes
+ WorkingDirectory=/var/lib/quicknotes
+-Environment=ADDR=:9090
++Environment=ADDR=:8080
+ Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+ Environment=SEED_PATH=/var/lib/quicknotes/seed.json
+ ExecStart=/usr/local/bin/quicknotes
+
+changed: [vm]
+
+RUNNING HANDLER [Restart quicknotes] *******************************************
+changed: [vm]
+
+PLAY RECAP *********************************************************************
+vm  : ok=7    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+### Design questions
+
+**e) Why the second run reports `changed=0`.**
+The modules compare the wanted result with what is already on disk. `template` renders the file and compares its checksum plus owner, group, and mode. If everything matches, nothing changes. On a second run nothing differs, so `changed=0`.
+
+**f) Using `shell: 'echo "ADDR=..." > /etc/.../quicknotes.service'` instead.**
+It always reports `changed`, so the handler restarts every run. `--check` and `--diff` cannot preview it. It overwrites the whole file, potentially breaking it. It also sets no owner or mode. The `template` module avoids all of this.
+
+**g) The bug `--check --diff` catches that plain `--check` misses.**
+`--check` only says a task would change. `--diff` shows the exact lines. A typo that renders an empty `ADDR=` still looks like a normal "would change" under `--check`, but `--diff` shows the bad line before it deploys.


### PR DESCRIPTION
## Goal
Deploy QuickNotes to the Lab 5 VM with an idempotent Ansible playbook.

## Changes

- Add `ansible/` with playbook, inventory, systemd unit template, and the static binary.
- Add `submissions/lab7.md` with run recaps, health check, and design answers.

## Testing

- First run: `changed=7` and the restart handler fired; second run: `changed=0`.
- Changing one variable re-runs only the template task and the handler.
- `--check --diff` previews the unit-file change without applying it.
- `curl http://localhost:18080/health` returns `{"notes":4,"status":"ok"}`.

## Checklist

- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/labN.md` updated