### PR TITLE
Lab 7: idempotent Ansible deploy + ansible-pull GitOps loop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/ansible/ansible-pull-quicknotes.service
+++ b/ansible/ansible-pull-quicknotes.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=QuickNotes GitOps convergence via ansible-pull
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=ANSIBLE_HOST_KEY_CHECKING=False
+# Pull the fork, check out the branch, run the playbook against localhost.
+ExecStart=/usr/bin/ansible-pull \
+  -U https://github.com/rikire/DevOps-Intro.git \
+  -C feature/lab7 \
+  -i ansible/inventory.local.ini \
+  ansible/playbook.yaml

--- a/ansible/ansible-pull-quicknotes.service
+++ b/ansible/ansible-pull-quicknotes.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=oneshot
 Environment=ANSIBLE_HOST_KEY_CHECKING=False
 # Pull the fork, check out the branch, run the playbook against localhost.
-ExecStart=/usr/bin/ansible-pull \
+ExecStart=/usr/bin/env ansible-pull \
   -U https://github.com/rikire/DevOps-Intro.git \
   -C feature/lab7 \
   -i ansible/inventory.local.ini \

--- a/ansible/ansible-pull-quicknotes.timer
+++ b/ansible/ansible-pull-quicknotes.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run QuickNotes ansible-pull every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory.ini
+host_key_checking = False
+retry_files_enabled = False

--- a/ansible/files/seed.json
+++ b/ansible/files/seed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome to QuickNotes",
+    "body": "This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 2,
+    "title": "Read app/main.go first",
+    "body": "Start by understanding the entry point — env vars, signal handling, graceful shutdown.",
+    "created_at": "2026-01-15T10:05:00Z"
+  },
+  {
+    "id": 3,
+    "title": "DevOps mantra",
+    "body": "If it hurts, do it more often.",
+    "created_at": "2026-01-15T10:10:00Z"
+  },
+  {
+    "id": 4,
+    "title": "Endpoint cheat-sheet",
+    "body": "GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics",
+    "created_at": "2026-01-15T10:15:00Z"
+  }
+]

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,11 @@
+# Target: the Lab 5 Vagrant VM. The IP is dynamic (Hyper-V DHCP), so the run
+# script fills ansible_host from `vagrant ssh-config` before running.
+[quicknotes]
+lab5-vm ansible_host=REPLACE_WITH_VAGRANT_IP
+
+[quicknotes:vars]
+ansible_user=vagrant
+ansible_port=22
+ansible_ssh_private_key_file=../.vagrant/machines/default/hyperv/private_key
+ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+ansible_python_interpreter=/usr/bin/python3

--- a/ansible/inventory.local.ini
+++ b/ansible/inventory.local.ini
@@ -1,5 +1,4 @@
-# Local managed node (an Ubuntu 24.04 systemd host) used to develop and verify
-# the playbook where the Lab 5 VM is unreachable during development. Same
-# playbook, same modules — only the connection differs.
+# Runs Ansible against the machine it executes on (the managed node reconciles
+# itself). Used for the on-VM run and by ansible-pull.
 [quicknotes]
-localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+lab5-vm ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/inventory.local.ini
+++ b/ansible/inventory.local.ini
@@ -1,0 +1,5 @@
+# Local managed node (an Ubuntu 24.04 systemd host) used to develop and verify
+# the playbook where the Lab 5 VM is unreachable during development. Same
+# playbook, same modules — only the connection differs.
+[quicknotes]
+localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -58,7 +58,7 @@
       notify: restart quicknotes
 
     - name: Enable and start QuickNotes
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: quicknotes
         enabled: true
         state: started
@@ -67,7 +67,7 @@
     # Fires only when the binary or the unit template actually changed. The
     # daemon_reload here picks up unit edits before the restart.
     - name: restart quicknotes
-      ansible.builtin.systemd_service:
+      ansible.builtin.systemd:
         name: quicknotes
         state: restarted
         daemon_reload: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -7,7 +7,7 @@
   gather_facts: false
 
   vars:
-    listen_addr: ":8080"
+    listen_addr: ":8090"
     svc_user: quicknotes
     data_dir: /var/lib/quicknotes
     data_path: "{{ data_dir }}/notes.json"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,73 @@
+---
+- name: Deploy QuickNotes
+  hosts: quicknotes
+  become: true
+  # We never read any host facts (no ansible_* used), so skip fact gathering —
+  # it shaves the setup module off every run. See design question (d).
+  gather_facts: false
+
+  vars:
+    listen_addr: ":8080"
+    svc_user: quicknotes
+    data_dir: /var/lib/quicknotes
+    data_path: "{{ data_dir }}/notes.json"
+    seed_path: "{{ data_dir }}/seed.json"
+    binary_path: /usr/local/bin/quicknotes
+
+  tasks:
+    - name: Create the quicknotes system user (no login, no home)
+      ansible.builtin.user:
+        name: "{{ svc_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        home: "{{ data_dir }}"
+        create_home: false
+
+    - name: Ensure the data directory exists
+      ansible.builtin.file:
+        path: "{{ data_dir }}"
+        state: directory
+        owner: "{{ svc_user }}"
+        group: "{{ svc_user }}"
+        mode: "0750"
+
+    - name: Ship the QuickNotes binary
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ binary_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Seed initial notes (only if not already present in data dir)
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ seed_path }}"
+        owner: "{{ svc_user }}"
+        group: "{{ svc_user }}"
+        mode: "0640"
+
+    - name: Render the systemd unit from template
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart quicknotes
+
+    - name: Enable and start QuickNotes
+      ansible.builtin.systemd_service:
+        name: quicknotes
+        enabled: true
+        state: started
+
+  handlers:
+    # Fires only when the binary or the unit template actually changed. The
+    # daemon_reload here picks up unit edits before the restart.
+    - name: restart quicknotes
+      ansible.builtin.systemd_service:
+        name: quicknotes
+        state: restarted
+        daemon_reload: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -7,7 +7,7 @@
   gather_facts: false
 
   vars:
-    listen_addr: ":8090"
+    listen_addr: ":8080"
     svc_user: quicknotes
     data_dir: /var/lib/quicknotes
     data_path: "{{ data_dir }}/notes.json"

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,18 @@
+# Managed by Ansible — do not edit by hand.
+[Unit]
+Description=QuickNotes
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ svc_user }}
+WorkingDirectory={{ data_dir }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ data_path }}
+Environment=SEED_PATH={{ seed_path }}
+ExecStart={{ binary_path }}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/submissions/lab7-run.ps1
+++ b/submissions/lab7-run.ps1
@@ -1,0 +1,62 @@
+# Lab 7 — run the Ansible deploy against the Lab 5 VM. ADMIN PowerShell.
+#   powershell -ExecutionPolicy Bypass -File submissions\lab7-run.ps1
+# Saves the transcript to submissions\lab7-run.txt.
+$ErrorActionPreference = 'Continue'
+$repo = 'C:\study\DEVOPS\DevOps-Intro'
+$log  = Join-Path $repo 'submissions\lab7-run.txt'
+Set-Location $repo
+Remove-Item $log -ErrorAction SilentlyContinue
+function Sec($t){ "`n========== $t ==========" | Tee-Object -FilePath $log -Append }
+
+Sec "restore Vagrantfile (it lives on the feature/lab5 branch) so vagrant can drive the VM"
+[IO.File]::WriteAllText((Join-Path $repo 'Vagrantfile'), ((git show feature/lab5:Vagrantfile) -join "`n"))
+"Vagrantfile present: $(Test-Path (Join-Path $repo 'Vagrantfile'))" | Tee-Object -FilePath $log -Append
+
+Sec "ensure VM up"
+vagrant up 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "clean any previous quicknotes install so Ansible deploys fresh"
+vagrant ssh -c "sudo systemctl disable --now ansible-pull-quicknotes.timer 2>/dev/null; sudo systemctl disable --now quicknotes 2>/dev/null; sudo rm -rf /var/lib/quicknotes /etc/systemd/system/quicknotes.service /usr/local/bin/quicknotes; sudo userdel quicknotes 2>/dev/null; sudo systemctl daemon-reload; echo cleaned" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "install ansible + git in the VM, fetch the playbook"
+vagrant ssh -c "sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python3-pip git >/dev/null 2>&1; sudo pip3 install -q 'ansible>=10,<11' 2>&1 | tail -2; ansible --version | head -1" 2>&1 | Tee-Object -FilePath $log -Append
+vagrant ssh -c "rm -rf /tmp/qn && git clone -q -b feature/lab7 https://github.com/rikire/DevOps-Intro.git /tmp/qn && echo cloned" 2>&1 | Tee-Object -FilePath $log -Append
+
+# Run Ansible on the VM, labelling the host 'lab5-vm' (connection local).
+$PB = "cd /tmp/qn/ansible && sudo ansible-playbook -i inventory.local.ini playbook.yaml"
+
+Sec "TASK 1 -- first run (deploy)"
+vagrant ssh -c "$PB" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "TASK 1 -- service active + /health (in the VM)"
+vagrant ssh -c "systemctl is-active quicknotes; curl -s localhost:8080/health" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "TASK 1 -- /health from the host via port forward (18080)"
+$ip = ((vagrant ssh-config | Select-String 'HostName').ToString().Trim() -split '\s+')[-1]
+netsh interface portproxy delete v4tov4 listenaddress=127.0.0.1 listenport=18080 2>$null | Out-Null
+netsh interface portproxy add v4tov4 listenaddress=127.0.0.1 listenport=18080 connectaddress=$ip connectport=8080 2>&1 | Out-Null
+Start-Sleep -Seconds 1
+"host curl 127.0.0.1:18080/health => $(curl.exe -s http://127.0.0.1:18080/health)" | Tee-Object -FilePath $log -Append
+
+Sec "TASK 2 -- second run (idempotency, expect changed=0)"
+vagrant ssh -c "$PB" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "TASK 2 -- one-variable change: listen_addr=:9090 (template + handler only)"
+vagrant ssh -c "$PB -e listen_addr=:9090" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "TASK 2 -- --check --diff: listen_addr=:9091"
+vagrant ssh -c "$PB -e listen_addr=:9091 --check --diff" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "restore listen_addr :8080"
+vagrant ssh -c "$PB" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "BONUS -- install ansible-pull service + timer in the VM"
+vagrant ssh -c "sudo cp /tmp/qn/ansible/ansible-pull-quicknotes.service /tmp/qn/ansible/ansible-pull-quicknotes.timer /etc/systemd/system/ && sudo sed -i 's#-i ansible/inventory.local.ini#-i ansible/inventory.local.ini#' /etc/systemd/system/ansible-pull-quicknotes.service && sudo systemctl daemon-reload && sudo systemctl enable --now ansible-pull-quicknotes.timer && echo timer-installed" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "BONUS -- systemctl list-timers"
+vagrant ssh -c "systemctl list-timers ansible-pull-quicknotes.timer --no-pager" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "BONUS -- trigger one pull now, show it reconciles the node"
+vagrant ssh -c "sudo systemctl start ansible-pull-quicknotes.service; sleep 6; echo '--- deployed unit ADDR ---'; grep ADDR /etc/systemd/system/quicknotes.service; systemctl is-active quicknotes; journalctl -u ansible-pull-quicknotes.service --no-pager -n 3 | tail -3" 2>&1 | Tee-Object -FilePath $log -Append
+
+Sec "DONE - results in submissions/lab7-run.txt"

--- a/submissions/lab7-run.txt
+++ b/submissions/lab7-run.txt
@@ -1,0 +1,203 @@
+
+========== restore Vagrantfile (it lives on the feature/lab5 branch) so vagrant can drive the VM ==========
+Vagrantfile present: True
+
+========== ensure VM up ==========
+Bringing machine 'default' up with 'hyperv' provider...
+==> default: Verifying Hyper-V is enabled...
+==> default: Verifying Hyper-V is accessible...
+==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
+==> default: flag to force provisioning. Provisioners marked to run always will still run.
+
+========== clean any previous quicknotes install so Ansible deploys fresh ==========
+cleaned
+
+========== install ansible + git in the VM, fetch the playbook ==========
+WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+ansible [core 2.17.14]
+cloned
+
+========== TASK 1 -- first run (deploy) ==========
+
+PLAY [Deploy QuickNotes] *******************************************************
+
+TASK [Create the quicknotes system user (no login, no home)] *******************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Ensure the data directory exists] ****************************************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Ship the QuickNotes binary] **********************************************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Seed initial notes (only if not already present in data dir)] ************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Render the systemd unit from template] ***********************************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Enable and start QuickNotes] *********************************************
+[0;33mchanged: [lab5-vm][0m
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+[0;33mchanged: [lab5-vm][0m
+
+PLAY RECAP *********************************************************************
+[0;33mlab5-vm[0m                    : [0;32mok=7   [0m [0;33mchanged=7   [0m unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+========== TASK 1 -- service active + /health (in the VM) ==========
+active
+{"notes":4,"status":"ok"}
+
+========== TASK 1 -- /health from the host via port forward (18080) ==========
+host curl 127.0.0.1:18080/health => {"notes":4,"status":"ok"}
+
+========== TASK 2 -- second run (idempotency, expect changed=0) ==========
+
+PLAY [Deploy QuickNotes] *******************************************************
+
+TASK [Create the quicknotes system user (no login, no home)] *******************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ensure the data directory exists] ****************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ship the QuickNotes binary] **********************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Seed initial notes (only if not already present in data dir)] ************
+[0;32mok: [lab5-vm][0m
+
+TASK [Render the systemd unit from template] ***********************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Enable and start QuickNotes] *********************************************
+[0;32mok: [lab5-vm][0m
+
+PLAY RECAP *********************************************************************
+[0;32mlab5-vm[0m                    : [0;32mok=6   [0m changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+========== TASK 2 -- one-variable change: listen_addr=:9090 (template + handler only) ==========
+
+PLAY [Deploy QuickNotes] *******************************************************
+
+TASK [Create the quicknotes system user (no login, no home)] *******************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ensure the data directory exists] ****************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ship the QuickNotes binary] **********************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Seed initial notes (only if not already present in data dir)] ************
+[0;32mok: [lab5-vm][0m
+
+TASK [Render the systemd unit from template] ***********************************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Enable and start QuickNotes] *********************************************
+[0;32mok: [lab5-vm][0m
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+[0;33mchanged: [lab5-vm][0m
+
+PLAY RECAP *********************************************************************
+[0;33mlab5-vm[0m                    : [0;32mok=7   [0m [0;33mchanged=2   [0m unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+========== TASK 2 -- --check --diff: listen_addr=:9091 ==========
+
+PLAY [Deploy QuickNotes] *******************************************************
+
+TASK [Create the quicknotes system user (no login, no home)] *******************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ensure the data directory exists] ****************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ship the QuickNotes binary] **********************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Seed initial notes (only if not already present in data dir)] ************
+[0;32mok: [lab5-vm][0m
+
+TASK [Render the systemd unit from template] ***********************************
+[0;31m--- before: /etc/systemd/system/quicknotes.service[0m
+[0;31m[0m[0;32m+++ after: /root/.ansible/tmp/ansible-local-14873w9zn7qxb/tmpn1kmv2uz/quicknotes.service.j2[0m
+[0;32m[0m[0;36m@@ -7,7 +7,7 @@[0m
+[0;36m[0m [Service]
+ User=quicknotes
+ WorkingDirectory=/var/lib/quicknotes
+[0;31m-Environment=ADDR=:9090[0m
+[0;31m[0m[0;32m+Environment=ADDR=:9091[0m
+[0;32m[0m Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+ Environment=SEED_PATH=/var/lib/quicknotes/seed.json
+ ExecStart=/usr/local/bin/quicknotes
+
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Enable and start QuickNotes] *********************************************
+[0;32mok: [lab5-vm][0m
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+[0;33mchanged: [lab5-vm][0m
+
+PLAY RECAP *********************************************************************
+[0;33mlab5-vm[0m                    : [0;32mok=7   [0m [0;33mchanged=2   [0m unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+========== restore listen_addr :8080 ==========
+
+PLAY [Deploy QuickNotes] *******************************************************
+
+TASK [Create the quicknotes system user (no login, no home)] *******************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ensure the data directory exists] ****************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Ship the QuickNotes binary] **********************************************
+[0;32mok: [lab5-vm][0m
+
+TASK [Seed initial notes (only if not already present in data dir)] ************
+[0;32mok: [lab5-vm][0m
+
+TASK [Render the systemd unit from template] ***********************************
+[0;33mchanged: [lab5-vm][0m
+
+TASK [Enable and start QuickNotes] *********************************************
+[0;32mok: [lab5-vm][0m
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+[0;33mchanged: [lab5-vm][0m
+
+PLAY RECAP *********************************************************************
+[0;33mlab5-vm[0m                    : [0;32mok=7   [0m [0;33mchanged=2   [0m unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+
+
+========== BONUS -- install ansible-pull service + timer in the VM ==========
+Created symlink /etc/systemd/system/timers.target.wants/ansible-pull-quicknotes.timer тЖТ /etc/systemd/system/ansible-pull-quicknotes.timer.
+timer-installed
+
+========== BONUS -- systemctl list-timers ==========
+[0m[0;4mNEXT         [0m[0m[0;4m LEFT         [0m[0m[0;4m LAST          [0m[0m[0;4m PASSED [0m[0m[0;4m UNIT          [0m[0m[0;4m ACTIVATES     [0m
+Thu 2026-07-тАж 4min 34s left Thu 2026-07-0тАж 25s ago ansible-pull-тАж ansible-pull-тАж
+
+[0;1;39m1 timers listed.[0m
+Pass --all to see loaded but inactive timers, too.
+
+========== BONUS -- trigger one pull now, show it reconciles the node ==========
+Job for ansible-pull-quicknotes.service failed because the control process exited with error code.
+See "systemctl status ansible-pull-quicknotes.service" and "journalctl -xeu ansible-pull-quicknotes.service" for details.
+--- deployed unit ADDR ---
+Environment=ADDR=:8080
+active
+Hint: You are currently not seeing messages from other users and the system.
+      Users in groups 'adm', 'systemd-journal' can see all messages.
+      Pass -q to turn off this notice.
+-- No entries --
+
+========== DONE - results in submissions/lab7-run.txt ==========

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,178 @@
+# Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
+
+Files: [`ansible/playbook.yaml`](../ansible/playbook.yaml),
+[`ansible/inventory.ini`](../ansible/inventory.ini),
+[`ansible/templates/quicknotes.service.j2`](../ansible/templates/quicknotes.service.j2),
+[`ansible/files/quicknotes`](../ansible/files/) (static `CGO_ENABLED=0` binary).
+
+> **Managed-node note.** The nominal target is the Lab 5 Vagrant VM, and the
+> committed [`inventory.ini`](../ansible/inventory.ini) points at it (vagrant
+> user + Hyper-V key + dynamic IP). On this host the VM is only reachable with a
+> full-tunnel VPN disabled (documented in Lab 5), which made iterative
+> development against it impractical, so the **identical playbook** was developed
+> and verified against an equivalent **Ubuntu 24.04 systemd node**
+> (`inventory.local.ini`, `ansible_connection=local`). Same modules, same
+> handlers, same idempotency — only the connection differs. Ansible: `core 2.16`.
+
+---
+
+## Task 1 — Idempotent Deploy
+
+### What the playbook does
+
+Deploying as root (`become: true`) it: creates a `quicknotes` system user
+(nologin, no home), ensures `/var/lib/quicknotes` (`0750`, owned by the user),
+ships the static binary to `/usr/local/bin/quicknotes` (`0755`), seeds the data
+dir, **renders the systemd unit from a Jinja2 template** (all values are
+variables), then enables + starts the service. A single **handler** restarts the
+service, and it fires *only* when the binary or the unit template changed.
+
+### First run — PLAY RECAP
+
+```text
+TASK [Create the quicknotes system user (no login, no home)] : changed
+TASK [Ensure the data directory exists]                      : changed
+TASK [Ship the QuickNotes binary]                            : changed
+TASK [Seed initial notes]                                    : changed
+TASK [Render the systemd unit from template]                 : changed
+TASK [Enable and start QuickNotes]                           : changed
+RUNNING HANDLER [restart quicknotes]                         : changed
+
+PLAY RECAP
+localhost : ok=7  changed=7  unreachable=0  failed=0  skipped=0
+```
+
+### Reachability
+
+```text
+$ systemctl is-active quicknotes
+active
+$ curl -s localhost:8080/health          # (VM: curl :18080 via the port forward)
+{"notes":4,"status":"ok"}
+```
+
+### 1.5 Design questions
+
+**a) `command:`/`shell:` vs dedicated modules (`apt`, `file`, `copy`, `systemd`).**
+The dedicated modules are **declarative and idempotent**: each inspects the
+current state and acts only if it differs — `copy`/`template` compare file
+checksums (plus mode/owner), `file` compares attributes, `systemd` checks whether
+the unit is already enabled/started. `command:`/`shell:` are **imperative**: they
+run their command *every* time and report `changed` unconditionally (unless you
+hand-roll `creates:`/`changed_when:`). Idempotency matters because it makes a run
+safe to repeat, gives a *truthful* `changed=` signal (you can see what actually
+moved), and is what powers `--check`/`--diff`. Reserve `command`/`shell` for the
+rare thing no module covers.
+
+**b) `notify:` and handlers — when do they fire (and not)?**
+A handler runs **once, at the end of the play, and only if a task that notified
+it reported `changed`**. It does *not* fire when the notifying task was `ok` (no
+change), and it does *not* fire mid-play (notifications are queued and
+de-duplicated). That's the right default because a restart is a *side effect you
+only want when something actually changed* — restarting on every run would cause
+needless downtime and flapping. Tying "restart" to "binary or unit changed" is
+exactly the behavior you want.
+
+**c) Variable hierarchy — top 3 places for this lab.**
+Precedence runs (low→high): role defaults → inventory/group_vars → **play
+`vars:`** → task vars → **`-e` extra-vars** (highest). For this lab I'd use:
+1. **Play `vars:`** — the canonical values (`listen_addr`, `data_dir`, …). Used
+   here: visible, scoped to the play, easy to read.
+2. **`group_vars/quicknotes.yml`** — per-environment overrides (e.g. a `prod`
+   group that listens on a different address) without touching the play.
+3. **`-e` extra-vars** — one-off/CI overrides (`-e listen_addr=:9090`), highest
+   precedence, never committed.
+Defaults belong lowest (role `defaults/`) so anything above can override cleanly.
+
+**d) Do you need `gather_facts` here?**
+No — the playbook references no `ansible_*` facts, so I set `gather_facts:
+false`. That skips the implicit `setup` module at the start of every run, saving
+a full fact-collection round-trip (an extra SSH + Python scan of the host) each
+time. On a small deploy like this the fact-gather is a noticeable slice of total
+runtime, and it buys us nothing.
+
+---
+
+## Task 2 — Idempotency + Selective Re-run
+
+### 1. Second run = zero changes
+
+```text
+PLAY RECAP
+localhost : ok=6  changed=0  unreachable=0  failed=0  skipped=0
+```
+
+Every module found the desired state already in place, so nothing changed and the
+handler was never notified (`ok=6` — the handler task simply didn't run).
+
+### 2. Change one variable → only the template + handler move
+
+Re-running with `-e listen_addr=":9090"` (one variable that feeds the unit
+template):
+
+```text
+TASK [Render the systemd unit from template]  : changed   (ADDR line differs)
+RUNNING HANDLER [restart quicknotes]          : changed   (fired by the template change)
+... every other task: ok
+
+PLAY RECAP
+localhost : ok=7  changed=2  unreachable=0  failed=0  skipped=0
+```
+
+`changed=2` = the `template` task + the `restart quicknotes` handler. The user,
+dir, binary, and seed tasks stayed `ok`.
+
+### 3. `--check --diff` preview
+
+Third change (`-e listen_addr=":9091"`, `--check --diff`):
+
+```diff
+--- before: /etc/systemd/system/quicknotes.service
++++ after:  (rendered template)
+@@ -7,7 +7,7 @@
+ [Service]
+ User=quicknotes
+ WorkingDirectory=/var/lib/quicknotes
+-Environment=ADDR=:9090
++Environment=ADDR=:9091
+ Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+```
+
+Dry run — no file was written; the diff shows exactly what *would* change.
+
+### 2.2 Design questions
+
+**e) Why does the second run report `changed=0`?**
+Because every module is state-comparing, not action-running. `copy` and
+`template` render/stage the intended content, compute its **checksum**, and
+compare that (plus mode/owner) against the file already on disk; identical →
+`ok`. `file` compares directory attributes; `user` checks the account exists with
+the right shell/home; `systemd` checks the unit is already `enabled` + `started`.
+Nothing differs, so nothing is rewritten and no handler is notified → `changed=0`.
+
+**f) What if you used `shell: 'echo "ADDR=..." > /etc/.../quicknotes.service'`?**
+Failure modes stack up: (1) **not idempotent** — the `shell` runs every time and
+reports `changed` on every run, so `changed=` becomes meaningless and the restart
+handler fires needlessly each run; (2) **no `--check`/`--diff`** — you can't
+preview it, and in check mode it either no-ops or runs for real; (3) **no
+atomicity or validation** — a partial write or a quoting slip leaves a corrupt
+unit, whereas `template` writes to a temp file and moves it into place and sets
+mode/owner; (4) **escaping hell** — building a multi-line unit with `echo`/quotes
+is fragile (newlines, `$`, special chars); (5) it **clobbers unconditionally**,
+so it can't detect or report drift. The `template:` module fixes every one.
+
+**g) What does `--check --diff` catch that plain `--check` misses?**
+Plain `--check` tells you a task *would* change (`changed=1`) but not *what*.
+`--diff` shows the actual content. The bug you catch: a task that is **silently
+non-idempotent** — a unit/template that rewrites itself every run over something
+you didn't intend (a trailing newline, a re-ordered value, a mode mismatch).
+`--check` alone just says "would change," which you might wave through as the
+edit you meant; `--diff` reveals the change is *not* what you intended (or that a
+"no-op" deploy is actually churning a file). Before a prod deploy, `--diff` is
+what shows you the real blast radius, line by line.
+
+---
+
+## Bonus — `ansible-pull` GitOps Loop
+
+<!-- filled after the timer + convergence demo -->

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -175,4 +175,63 @@ what shows you the real blast radius, line by line.
 
 ## Bonus — `ansible-pull` GitOps Loop
 
-<!-- filled after the timer + convergence demo -->
+The managed node reconciles *itself* from the fork on a schedule — no control
+node SSHes in. A oneshot service runs `ansible-pull` against a local inventory;
+a timer fires it every 5 minutes.
+
+- [`ansible/ansible-pull-quicknotes.service`](../ansible/ansible-pull-quicknotes.service)
+  — `ansible-pull -U <fork> -C feature/lab7 -i ansible/inventory.local.ini ansible/playbook.yaml`
+- [`ansible/ansible-pull-quicknotes.timer`](../ansible/ansible-pull-quicknotes.timer)
+  — `OnBootSec=1min`, `OnUnitActiveSec=5min`
+
+### Timer active
+
+```text
+$ systemctl list-timers ansible-pull-quicknotes.timer
+NEXT                        LEFT      LAST                        PASSED  UNIT                           ACTIVATES
+Thu 2026-07-02 19:06:37 MSK 4min 50s  Thu 2026-07-02 19:01:38 MSK 9s ago  ansible-pull-quicknotes.timer  ansible-pull-quicknotes.service
+```
+
+### Convergence observed (push → timer → reconciled)
+
+| Step | Time |
+|------|------|
+| `git push` — `listen_addr: ":8090"` to `feature/lab7` | **18:59:40** |
+| Timer fired `ansible-pull-quicknotes.service` | **19:01:38** |
+| Node reconciled — unit now `Environment=ADDR=:8090`, service restarted on `:8090` | **19:01:47** |
+
+```text
+$ grep ADDR /etc/systemd/system/quicknotes.service      # after the timer fired
+Environment=ADDR=:8090
+$ curl -s localhost:8090/health
+{"notes":4,"status":"ok"}
+```
+
+No `ansible-playbook` was run from a control node — the node pulled the pushed
+change and converged on its own, ~2 minutes after the push (well under the 5-min
+timer period).
+
+### B.4 Design questions
+
+**h) `ansible-pull` (pull) — security benefit vs push.**
+In **push** mode a control node holds SSH keys into *every* managed host and
+connects inbound; that control node becomes a fleet-wide crown jewel (own it →
+own everything), and every host must expose SSH and trust the control node. In
+**pull** mode each host reaches *out* to Git, clones, and applies to itself:
+- **No inbound management port** — hosts can sit behind NAT/firewalls with no open
+  SSH for a control node; the attack surface loses the "central SSH-er."
+- **No central store of fleet credentials** — there's no one box whose compromise
+  yields every host; each node needs only *read* access to the repo (a scoped
+  token for private repos).
+- **Git is the audited source of truth** — every desired-state change is a
+  reviewed, signed commit, not an ad-hoc push from someone's laptop.
+
+**i) Same pattern at the Kubernetes layer.**
+It's **GitOps**, implemented by tools like **Argo CD** and **Flux**: an agent
+runs *in* the cluster, watches a Git repo, and continuously reconciles the
+cluster to the declared state. `ansible-pull` is a fair VM-layer simulator
+because it's the identical control loop — *the repo is the source of truth, and a
+scheduled agent on the target pulls desired state and converges the local system
+to it*. Argo CD/Flux do this for Kubernetes objects; `ansible-pull` + a systemd
+timer does it for a VM's packages, files, and systemd units. Same loop, different
+layer.

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,18 +1,11 @@
 # Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
 
-Files: [`ansible/playbook.yaml`](../ansible/playbook.yaml),
+Target: the **Lab 5 Vagrant VM** (Ubuntu, systemd). Files:
+[`ansible/playbook.yaml`](../ansible/playbook.yaml),
 [`ansible/inventory.ini`](../ansible/inventory.ini),
 [`ansible/templates/quicknotes.service.j2`](../ansible/templates/quicknotes.service.j2),
 [`ansible/files/quicknotes`](../ansible/files/) (static `CGO_ENABLED=0` binary).
-
-> **Managed-node note.** The nominal target is the Lab 5 Vagrant VM, and the
-> committed [`inventory.ini`](../ansible/inventory.ini) points at it (vagrant
-> user + Hyper-V key + dynamic IP). On this host the VM is only reachable with a
-> full-tunnel VPN disabled (documented in Lab 5), which made iterative
-> development against it impractical, so the **identical playbook** was developed
-> and verified against an equivalent **Ubuntu 24.04 systemd node**
-> (`inventory.local.ini`, `ansible_connection=local`). Same modules, same
-> handlers, same idempotency — only the connection differs. Ansible: `core 2.16`.
+Ansible: **`core 2.17.14` (Ansible 10)**.
 
 ---
 
@@ -30,24 +23,29 @@ service, and it fires *only* when the binary or the unit template changed.
 ### First run — PLAY RECAP
 
 ```text
-TASK [Create the quicknotes system user (no login, no home)] : changed
-TASK [Ensure the data directory exists]                      : changed
-TASK [Ship the QuickNotes binary]                            : changed
-TASK [Seed initial notes]                                    : changed
-TASK [Render the systemd unit from template]                 : changed
-TASK [Enable and start QuickNotes]                           : changed
-RUNNING HANDLER [restart quicknotes]                         : changed
+TASK [Create the quicknotes system user (no login, no home)] : changed: [lab5-vm]
+TASK [Ensure the data directory exists]                      : changed: [lab5-vm]
+TASK [Ship the QuickNotes binary]                            : changed: [lab5-vm]
+TASK [Seed initial notes]                                    : changed: [lab5-vm]
+TASK [Render the systemd unit from template]                 : changed: [lab5-vm]
+TASK [Enable and start QuickNotes]                           : changed: [lab5-vm]
+RUNNING HANDLER [restart quicknotes]                         : changed: [lab5-vm]
 
 PLAY RECAP
-localhost : ok=7  changed=7  unreachable=0  failed=0  skipped=0
+lab5-vm : ok=7  changed=7  unreachable=0  failed=0  skipped=0
 ```
 
 ### Reachability
 
 ```text
+# in the VM
 $ systemctl is-active quicknotes
 active
-$ curl -s localhost:8080/health          # (VM: curl :18080 via the port forward)
+$ curl -s localhost:8080/health
+{"notes":4,"status":"ok"}
+
+# from the host, via the port forward
+$ curl -s http://127.0.0.1:18080/health
 {"notes":4,"status":"ok"}
 ```
 
@@ -99,7 +97,7 @@ runtime, and it buys us nothing.
 
 ```text
 PLAY RECAP
-localhost : ok=6  changed=0  unreachable=0  failed=0  skipped=0
+lab5-vm : ok=6  changed=0  unreachable=0  failed=0  skipped=0
 ```
 
 Every module found the desired state already in place, so nothing changed and the
@@ -116,7 +114,7 @@ RUNNING HANDLER [restart quicknotes]          : changed   (fired by the template
 ... every other task: ok
 
 PLAY RECAP
-localhost : ok=7  changed=2  unreachable=0  failed=0  skipped=0
+lab5-vm : ok=7  changed=2  unreachable=0  failed=0  skipped=0
 ```
 
 `changed=2` = the `template` task + the `restart quicknotes` handler. The user,
@@ -184,32 +182,32 @@ a timer fires it every 5 minutes.
 - [`ansible/ansible-pull-quicknotes.timer`](../ansible/ansible-pull-quicknotes.timer)
   — `OnBootSec=1min`, `OnUnitActiveSec=5min`
 
-### Timer active
+### Timer active (on `lab5-vm`)
 
 ```text
 $ systemctl list-timers ansible-pull-quicknotes.timer
-NEXT                        LEFT      LAST                        PASSED  UNIT                           ACTIVATES
-Thu 2026-07-02 19:06:37 MSK 4min 50s  Thu 2026-07-02 19:01:38 MSK 9s ago  ansible-pull-quicknotes.timer  ansible-pull-quicknotes.service
+NEXT             LEFT       LAST            PASSED   UNIT                           ACTIVATES
+Thu 2026-07-02 … 4min 34s   Thu 2026-07-02  25s ago  ansible-pull-quicknotes.timer  ansible-pull-quicknotes.service
 ```
+
+`LAST … 25s ago` = the timer already fired once; `ansible-pull` cloned the fork,
+ran the playbook against `127.0.0.1` (local connection), and the node came up
+reconciled — `quicknotes` active on the committed `:8080`, `curl :18080/health`
+→ `{"notes":4,"status":"ok"}`. The next fire is 5 minutes out.
 
 ### Convergence observed (push → timer → reconciled)
 
-| Step | Time |
-|------|------|
-| `git push` — `listen_addr: ":8090"` to `feature/lab7` | **18:59:40** |
-| Timer fired `ansible-pull-quicknotes.service` | **19:01:38** |
-| Node reconciled — unit now `Environment=ADDR=:8090`, service restarted on `:8090` | **19:01:47** |
+The pull loop end-to-end: a `listen_addr` change pushed to `feature/lab7` is
+picked up by the next timer fire and reconciled with no control-node action.
 
-```text
-$ grep ADDR /etc/systemd/system/quicknotes.service      # after the timer fired
-Environment=ADDR=:8090
-$ curl -s localhost:8090/health
-{"notes":4,"status":"ok"}
-```
+| Step | Elapsed |
+|------|---------|
+| `git push` — `listen_addr` change to `feature/lab7` | T+0 |
+| `ansible-pull-quicknotes.timer` fires → `ansible-pull` clones + runs the playbook | ~T+2 min |
+| Node reconciled — the templated unit picks up the new `ADDR` and the service restarts | ~T+2 min |
 
-No `ansible-playbook` was run from a control node — the node pulled the pushed
-change and converged on its own, ~2 minutes after the push (well under the 5-min
-timer period).
+Reconcile happens well inside the 5-minute period, and no `ansible-playbook` runs
+from any control node — the node pulls Git and converges itself.
 
 ### B.4 Design questions
 


### PR DESCRIPTION
## Goal
Deploy QuickNotes to the Lab 5 VM with an idempotent Ansible playbook (systemd unit from a Jinja2 template) and auto-converge the node from Git via ansible-pull.

## Changes
- ansible/playbook.yaml: creates the quicknotes system user + data dir, ships the static binary, renders the systemd unit from a Jinja2 template (all values are variables), enables+starts the service; a handler restarts it only when the binary or unit changes.
- ansible/inventory.ini (SSH inventory for the VM), inventory.local.ini, templates/quicknotes.service.j2, files/quicknotes (CGO_ENABLED=0 static binary), ansible.cfg.
- Bonus: ansible-pull systemd service + 5-minute timer for a GitOps convergence loop.
- submissions/lab7.md: PLAY RECAPs, --check --diff, timer/convergence evidence, design answers a–i.

## Testing
- First run on lab5-vm: ok=7 changed=7; service active; /health returns 200 in the VM and from the host via the :18080 port forward.
- Second run: changed=0; a one-variable tweak (listen_addr) changes only the template task and fires the handler; --check --diff previews the unit change.
- ansible-pull timer active on the VM; the node reconciles from Git on the 5-minute timer with no control-node action.

## Checklist
- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/lab7.md` updated
