### PR TITLE
Feature/lab10 – Submission: Ship QuickNotes to GHCR and Hugging Face Spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,160 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "app/**"
+      - ".github/workflows/ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOFLAGS: -buildvcs=false
+
+jobs:
+  vet:
+    name: vet (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.25.11"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.mod
+
+      - name: Run go vet
+        working-directory: app
+        run: go vet ./...
+
+  test:
+    name: test (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.25.11"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.mod
+
+      - name: Run tests with race detector
+        working-directory: app
+        run: go test -race -count=1 ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.25.11"
+          cache: true
+          cache-dependency-path: app/go.mod
+
+      - name: Install golangci-lint
+        working-directory: app
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+
+      - name: Run golangci-lint
+        working-directory: app
+        run: golangci-lint run
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.25.11"
+          cache: true
+          cache-dependency-path: app/go.mod
+
+      - name: Install govulncheck
+        working-directory: app
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck
+        working-directory: app
+        run: govulncheck ./...
+
+  ci-ok:
+    name: ci-ok
+    if: always()
+    needs:
+      - vet
+      - test
+      - lint
+      - govulncheck
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check all required jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "At least one required job failed"
+            exit 1
+          fi
+
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "At least one required job was cancelled"
+            exit 1
+          fi
+
+          echo "All required jobs passed"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_SUFFIX: quicknotes
+
+jobs:
+  quicknotes-image:
+    name: Build and push QuickNotes image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Validate release tag and image name
+        shell: bash
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be semantic version format like v0.1.0"
+            exit 1
+          fi
+
+          repository="${GITHUB_REPOSITORY,,}"
+          echo "IMAGE_NAME=${REGISTRY}/${repository}/${IMAGE_SUFFIX}" >> "$GITHUB_ENV"
+          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build and push image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./app
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.25.11-alpine AS builder
+
+WORKDIR /src
+
+# Cache module downloads independently from source-code changes.
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build -trimpath -ldflags="-s -w" -o /out/quicknotes .
+
+# Distroless contains no shell, curl, or wget, so provide a dedicated probe.
+RUN <<'EOF'
+cat > /tmp/healthcheck.go <<'GO'
+package main
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	client := http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://127.0.0.1:8080/health")
+	if err != nil {
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}
+GO
+CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/healthcheck /tmp/healthcheck.go
+mkdir /out/data
+EOF
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /out/quicknotes /quicknotes
+COPY --from=builder /out/healthcheck /healthcheck
+COPY --from=builder /src/seed.json /seed.json
+# An empty named volume inherits this mount-point ownership on first use.
+COPY --chown=65532:65532 --from=builder /out/data /data
+
+USER nonroot:nonroot
+EXPOSE 8080
+ENV ADDR=:8080 \
+    DATA_PATH=/data/notes.json \
+    SEED_PATH=/seed.json
+ENTRYPOINT ["/quicknotes"]

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -37,6 +37,10 @@ func (s *Server) Routes() *http.ServeMux {
 	return mux
 }
 
+func (s *Server) Handler() http.Handler {
+	return securityHeaders(s.Routes())
+}
+
 type statusWriter struct {
 	http.ResponseWriter
 	code int

--- a/app/handlers_test.go
+++ b/app/handlers_test.go
@@ -31,8 +31,28 @@ func do(t *testing.T, srv *Server, method, target string, body any) *httptest.Re
 	}
 	req := httptest.NewRequest(method, target, &buf)
 	rec := httptest.NewRecorder()
-	srv.Routes().ServeHTTP(rec, req)
+	srv.Handler().ServeHTTP(rec, req)
 	return rec
+}
+
+func TestSecurityHeaders_AppliedToRoutes(t *testing.T) {
+	srv := newTestServer(t)
+	rec := do(t, srv, http.MethodGet, "/health", nil)
+
+	tests := map[string]string{
+		"Content-Security-Policy":      contentSecurityPolicy,
+		"X-Content-Type-Options":       "nosniff",
+		"X-Frame-Options":              "DENY",
+		"Referrer-Policy":              "no-referrer",
+		"Cache-Control":                "no-store",
+		"Cross-Origin-Resource-Policy": "same-origin",
+	}
+
+	for header, want := range tests {
+		if got := rec.Header().Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
 }
 
 func TestHealth_ReportsCount(t *testing.T) {
@@ -130,4 +150,3 @@ func TestMetrics_ExposesPrometheusFormat(t *testing.T) {
 		}
 	}
 }
-

--- a/app/main.go
+++ b/app/main.go
@@ -28,7 +28,7 @@ func main() {
 	server := NewServer(store)
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           server.Routes(),
+		Handler:           server.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 

--- a/app/security_headers.go
+++ b/app/security_headers.go
@@ -1,0 +1,20 @@
+package main
+
+import "net/http"
+
+const (
+	contentSecurityPolicy = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+)
+
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "no-referrer")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cloud/evidence-runbook.md
+++ b/cloud/evidence-runbook.md
@@ -1,0 +1,140 @@
+# Lab 10 Evidence Runbook
+
+Use this checklist after committing the lab files. Do not submit while the lab
+report still contains evidence placeholders.
+
+## 1. Release image to GHCR
+
+```bash
+git status --short
+git tag -a -s v0.1.0 -m "Lab 10 release"
+git push origin v0.1.0
+```
+
+Wait for the `release` workflow to finish green, then copy the GitHub Actions
+run URL into `submissions/lab10.md`.
+
+If the tag already exists and must be recreated before submission:
+
+```bash
+git tag -d v0.1.0
+git push origin :refs/tags/v0.1.0
+git tag -a -s v0.1.0 -m "Lab 10 release"
+git push origin v0.1.0
+```
+
+## 2. Verify unauthenticated GHCR pull
+
+If GitHub Packages created the image as private after the first push, change
+the package visibility to public in the GitHub UI.
+
+```bash
+docker logout ghcr.io
+docker rmi ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0 || true
+docker pull ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+docker run --rm -p 8080:8080 ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+```
+
+In another terminal:
+
+```bash
+curl -v http://localhost:8080/health
+curl -v http://localhost:8080/notes
+```
+
+Paste the relevant `docker pull`, `/health`, and `/notes` output into
+`submissions/lab10.md`.
+
+## 3. Deploy Hugging Face Space
+
+Create a public Docker Space named `quicknotes-lab10`, then push the contents
+of `cloud/hf/` to the Space repository root:
+
+```bash
+cp cloud/hf/Dockerfile /path/to/hf-space/Dockerfile
+cp cloud/hf/README.md /path/to/hf-space/README.md
+cd /path/to/hf-space
+git add Dockerfile README.md
+git commit -m "Deploy QuickNotes from GHCR image"
+git push
+```
+
+After the Space build is green:
+
+```bash
+export HF_SPACE_URL="https://kujifined-quicknotes-lab10.hf.space"
+curl -v "$HF_SPACE_URL/health"
+curl -v "$HF_SPACE_URL/notes"
+```
+
+Paste the real Space URL and both outputs into `submissions/lab10.md`.
+
+## 4. Measure Hugging Face warm latency
+
+```bash
+for i in 1 2 3 4 5; do
+  curl -o /dev/null -s -w "%{time_total}\n" "$HF_SPACE_URL/health"
+done
+```
+
+Sort the five values. The p50 is the third value after sorting.
+
+## 5. Measure Hugging Face cold latency
+
+Repeat three times:
+
+1. Leave the Space idle for at least 35 minutes.
+2. Run one cold request:
+
+```bash
+curl -o /dev/null -s -w "%{time_total}\n" "$HF_SPACE_URL/health"
+```
+
+Paste all three cold measurements into `submissions/lab10.md`.
+
+## 6. Run Cloudflare Tunnel bonus
+
+```bash
+docker run --rm -p 8080:8080 \
+  ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+```
+
+In another terminal:
+
+```bash
+cloudflared tunnel --url http://localhost:8080
+```
+
+Export the generated URL:
+
+```bash
+export CLOUDFLARE_URL="https://something-random.trycloudflare.com"
+curl -v "$CLOUDFLARE_URL/health"
+```
+
+Verify the same URL from a different network, for example a phone on cellular.
+
+## 7. Measure Cloudflare Tunnel latency
+
+```bash
+for i in $(seq 1 50); do
+  curl -o /dev/null -s -w "%{time_total}\n" "$CLOUDFLARE_URL/health"
+done | sort -n | tee cloud/cloudflare-times.txt
+
+awk 'NR==25{print "p50 approx:", $1} NR==48{print "p95 approx:", $1}' \
+  cloud/cloudflare-times.txt
+```
+
+Paste p50, p95, and the external verification note into
+`submissions/lab10.md` and `cloud/tunnel.md`.
+
+## 8. Final checks
+
+```bash
+marker="PENDING_REAL""_EVIDENCE"
+grep -RIn "$marker" submissions/lab10.md cloud/tunnel.md || true
+git status --short
+git log --show-signature -1
+```
+
+The grep command must produce no matches before final submission.

--- a/cloud/hf/Dockerfile
+++ b/cloud/hf/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0

--- a/cloud/hf/README.md
+++ b/cloud/hf/README.md
@@ -1,0 +1,17 @@
+---
+title: QuickNotes Lab 10
+emoji: 📝
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 8080
+pinned: false
+---
+
+# QuickNotes Lab 10
+
+QuickNotes deployed to Hugging Face Spaces from the immutable GHCR release image.
+
+Image:
+
+`ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0`

--- a/cloud/teardown.md
+++ b/cloud/teardown.md
@@ -1,0 +1,22 @@
+# Teardown
+
+## Hugging Face Space
+
+The Space can be deleted from:
+
+`https://huggingface.co/spaces/$HF_USERNAME/$HF_SPACE_NAME/settings`
+
+It can also be left public for the lab because the free tier costs $0.
+
+## Cloudflare Tunnel
+
+The quick tunnel is ephemeral. Stop it with `Ctrl+C`.
+
+The public `trycloudflare.com` URL becomes invalid after `cloudflared` exits.
+
+## Local container
+
+```bash
+docker ps
+docker stop <container-id>
+```

--- a/cloud/tunnel.md
+++ b/cloud/tunnel.md
@@ -7,19 +7,21 @@
 ## Local run
 
 ```bash
-docker run --rm -p 8080:8080 \
+docker run --rm -p 18080:8080 \
   ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
 ```
 
 ## Quick tunnel
 
 ```bash
-cloudflared tunnel --url http://localhost:8080
+docker run --rm --name quicknotes-lab10-cloudflared \
+  cloudflare/cloudflared:latest tunnel \
+  --url http://host.docker.internal:18080
 ```
 
 ## Public URL
 
-`PENDING_REAL_EVIDENCE: paste the ephemeral trycloudflare.com URL from cloudflared`
+`https://those-civilian-distinct-reveals.trycloudflare.com`
 
 Quick tunnels are ephemeral. The URL changes after restarting `cloudflared`.
 
@@ -32,6 +34,14 @@ curl -v "$CLOUDFLARE_URL/health"
 ```
 
 Expected result: `200 OK` and QuickNotes health JSON.
+
+Observed result:
+
+```text
+GET /health HTTP/2
+< HTTP/2 200
+{"notes":4,"status":"ok"}
+```
 
 ## Latency
 
@@ -47,5 +57,5 @@ awk 'NR==25{print "p50 approx:", $1} NR==48{print "p95 approx:", $1}' \
   cloud/cloudflare-times.txt
 ```
 
-- p50: `PENDING_REAL_EVIDENCE s`
-- p95: `PENDING_REAL_EVIDENCE s`
+- p50: `0.386789 s`
+- p95: `0.451584 s`

--- a/cloud/tunnel.md
+++ b/cloud/tunnel.md
@@ -1,0 +1,51 @@
+# Cloudflare Tunnel Notes
+
+## Image
+
+`ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0`
+
+## Local run
+
+```bash
+docker run --rm -p 8080:8080 \
+  ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+```
+
+## Quick tunnel
+
+```bash
+cloudflared tunnel --url http://localhost:8080
+```
+
+## Public URL
+
+`PENDING_REAL_EVIDENCE: paste the ephemeral trycloudflare.com URL from cloudflared`
+
+Quick tunnels are ephemeral. The URL changes after restarting `cloudflared`.
+
+## External verification
+
+Verify from a different network, for example a phone on cellular:
+
+```bash
+curl -v "$CLOUDFLARE_URL/health"
+```
+
+Expected result: `200 OK` and QuickNotes health JSON.
+
+## Latency
+
+50 warm runs against `/health`:
+
+```bash
+for i in $(seq 1 50); do
+  curl -o /dev/null -s -w "%{time_total}\n" \
+    "$CLOUDFLARE_URL/health"
+done | sort -n | tee cloud/cloudflare-times.txt
+
+awk 'NR==25{print "p50 approx:", $1} NR==48{print "p95 approx:", $1}' \
+  cloud/cloudflare-times.txt
+```
+
+- p50: `PENDING_REAL_EVIDENCE s`
+- p95: `PENDING_REAL_EVIDENCE s`

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,0 +1,333 @@
+# Lab 10 - Cloud Computing: QuickNotes Release and Cloud Deploy
+
+## Summary
+
+This lab ships QuickNotes as a production-style release:
+
+- signed Git tag `v0.1.0`
+- GitHub Actions release workflow
+- GHCR image with immutable and `latest` tags
+- Hugging Face Space deployment from the same release image
+- warm/cold latency measurements
+- Cloudflare Tunnel bonus comparison
+
+## Task 1 - CI-Automated Push to GHCR
+
+### Release workflow
+
+Path: `.github/workflows/release.yml`
+
+```yaml
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_SUFFIX: quicknotes
+
+jobs:
+  quicknotes-image:
+    name: Build and push QuickNotes image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Validate release tag and image name
+        shell: bash
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be semantic version format like v0.1.0"
+            exit 1
+          fi
+
+          repository="${GITHUB_REPOSITORY,,}"
+          echo "IMAGE_NAME=${REGISTRY}/${repository}/${IMAGE_SUFFIX}" >> "$GITHUB_ENV"
+          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build and push image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./app
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest
+```
+
+### Release tag
+
+```bash
+git tag -a -s v0.1.0 -m "Lab 10 release"
+git push origin v0.1.0
+```
+
+### Release run
+
+GitHub Actions run:
+
+`PENDING_REAL_EVIDENCE: paste the green release run URL after pushing tag v0.1.0`
+
+### Image
+
+```text
+ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+ghcr.io/kujifined/devops-intro/quicknotes:latest
+```
+
+### Clean pull evidence
+
+```bash
+docker rmi ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0 || true
+docker pull ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+docker run --rm -p 8080:8080 ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+curl -v http://localhost:8080/health
+```
+
+Result:
+
+```text
+PENDING_REAL_EVIDENCE: paste successful unauthenticated pull and /health output.
+```
+
+Package visibility note:
+
+```text
+PENDING_REAL_EVIDENCE: after the first GHCR push, set the package visibility to public in GitHub Packages if it was created as private. Verify the pull after docker logout ghcr.io.
+```
+
+### Design question a - OIDC vs GITHUB_TOKEN
+
+For pushing to GHCR from the same repository, `GITHUB_TOKEN` with `packages: write` is enough. GitHub Actions can authenticate to GitHub Packages without storing a long-lived PAT, and the token is already scoped to the repository workflow context.
+
+I would use OIDC when the workflow needs to cross a trust boundary, for example deploying to AWS, GCP, Azure, or another external platform. OIDC lets the workflow exchange its GitHub identity for short-lived, scoped, auditable cloud credentials. That avoids storing static cloud secrets in GitHub and allows the cloud side to verify claims such as repository, branch, tag, and workflow.
+
+### Design question b - `latest` vs immutable version tag
+
+The immutable tag, such as `v0.1.0`, is the source of truth for reproducible deployments and rollback. It identifies exactly which release artifact is running.
+
+The `latest` tag is still useful as a convenience pointer for humans, demos, local smoke tests, and environments that intentionally track the newest stable release. Production deployments should pin the immutable tag, but publishing `latest` improves discoverability and simple operational workflows.
+
+### Design question c - `packages: write` only
+
+The principle is least privilege: the workflow should receive only the permissions required for its job.
+
+This release workflow only needs to read repository contents and write packages. Granting broad write permissions would allow unnecessary repository mutations if a workflow dependency or build step were compromised. Narrow permissions limit blast radius: the release job can publish the container image, but it cannot freely modify code, pull requests, issues, or unrelated repository resources.
+
+## Task 2 - Hugging Face Spaces
+
+### Space URL
+
+`PENDING_REAL_EVIDENCE: paste the public Hugging Face Space URL, for example https://kujifined-quicknotes-lab10.hf.space`
+
+### Health check
+
+```bash
+curl -v "$HF_SPACE_URL/health"
+```
+
+Result:
+
+```text
+PENDING_REAL_EVIDENCE: paste HTTP 200 response and QuickNotes health JSON.
+```
+
+### Notes endpoint
+
+```bash
+curl -v "$HF_SPACE_URL/notes"
+```
+
+Result:
+
+```text
+PENDING_REAL_EVIDENCE: paste HTTP 200 response and QuickNotes notes JSON.
+```
+
+### Space Dockerfile
+
+Path in this repository: `cloud/hf/Dockerfile`
+
+```Dockerfile
+FROM ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+```
+
+### Space README.md
+
+Path in this repository: `cloud/hf/README.md`
+
+```markdown
+---
+title: QuickNotes Lab 10
+emoji: 📝
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 8080
+pinned: false
+---
+
+# QuickNotes Lab 10
+
+QuickNotes deployed to Hugging Face Spaces from the immutable GHCR release image.
+
+Image:
+
+`ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0`
+```
+
+### Why pull from GHCR?
+
+I chose to pull the already released GHCR image instead of rebuilding the application inside the Space. This makes the Space deployment use exactly the same artifact that CI built and published from the signed release tag. It improves reproducibility and makes debugging simpler: if the image works locally and in GHCR, the Space is only responsible for running that image.
+
+### Warm latency
+
+Five consecutive warm requests:
+
+```bash
+for i in 1 2 3 4 5; do
+  curl -o /dev/null -s -w "%{time_total}\n" \
+    "$HF_SPACE_URL/health"
+done
+```
+
+Measurements:
+
+```text
+PENDING_REAL_EVIDENCE
+PENDING_REAL_EVIDENCE
+PENDING_REAL_EVIDENCE
+PENDING_REAL_EVIDENCE
+PENDING_REAL_EVIDENCE
+```
+
+Sorted:
+
+```text
+PENDING_REAL_EVIDENCE
+```
+
+Warm p50:
+
+```text
+PENDING_REAL_EVIDENCE s
+```
+
+### Cold latency
+
+Each cold measurement was taken after 35+ minutes of inactivity.
+
+```text
+Cold #1: PENDING_REAL_EVIDENCE s
+Cold #2: PENDING_REAL_EVIDENCE s
+Cold #3: PENDING_REAL_EVIDENCE s
+```
+
+### Design question d - HF Spaces sleep vs Cloud Run scale to zero
+
+Both systems remove idle capacity, but they optimize for different products. Cloud Run is a production serverless container platform, so it invests heavily in fast scheduling, request routing, image caching, concurrency, and configurable minimum instances. HF Spaces is optimized for simple public demos and ML apps on a free tier. A sleeping Space may need to allocate demo capacity, restore the container environment, pull or prepare the image, and restart the app before the request can complete. That makes wakeups much slower, but the platform stays accessible without a credit card.
+
+### Design question e - Why `app_port: 8080`?
+
+QuickNotes listens on port `8080`. Hugging Face Docker Spaces default to port `7860`, which matches common Gradio demo apps. Without `app_port: 8080`, HF would route traffic to the wrong container port and the Space would look broken even if the process started correctly.
+
+### Design question f - Pulling from GHCR vs building in the Space
+
+Pulling from GHCR makes deployment consume the exact release artifact produced by CI. That is more reproducible and easier to debug because the same immutable image can be tested locally, pulled from a clean machine, and run in the Space.
+
+Building inside the Space can be convenient when the Space repository owns the whole app source, and HF build logs may directly show source-level build failures. The trade-off is weaker release traceability: HF may rebuild at a different time with different cache state or base image state unless everything is pinned carefully.
+
+## Bonus Task - Cloudflare Tunnel
+
+### Tunnel commands
+
+```bash
+docker run --rm -p 8080:8080 \
+  ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+
+cloudflared tunnel --url http://localhost:8080
+```
+
+### Public URL
+
+`PENDING_REAL_EVIDENCE: paste the ephemeral trycloudflare.com URL from cloudflared`
+
+### External verification
+
+```bash
+curl -v "$CLOUDFLARE_URL/health"
+```
+
+Result:
+
+```text
+PENDING_REAL_EVIDENCE: verified from phone on cellular or another network; /health returned 200 OK.
+```
+
+### Latency
+
+50 warm runs against `/health`.
+
+```text
+p50: PENDING_REAL_EVIDENCE s
+p95: PENDING_REAL_EVIDENCE s
+```
+
+### Comparison table
+
+| Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
+|--------|-------------------:|-----------------------------------:|
+| Warm p50 | PENDING_REAL_EVIDENCE s | PENDING_REAL_EVIDENCE s |
+| Warm p95 | PENDING_REAL_EVIDENCE s | PENDING_REAL_EVIDENCE s |
+| Cold start | PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s | N/A, continuously local |
+| Public URL stability | stable while Space exists | ephemeral on restart |
+| Cost | free | free |
+
+### Design question g - Architectural difference
+
+In HF Spaces, the container runs in Hugging Face infrastructure and users reach an app hosted by the platform. In Cloudflare Tunnel, the container runs on my local machine and Cloudflare proxies public traffic through an outbound tunnel.
+
+HF Spaces is more clearly "cloud hosted" because the workload itself runs in the provider's datacenter. Cloudflare Tunnel still uses cloud networking, but not cloud compute for the application. For users, the distinction matters less than reliability, latency, availability, and operational ownership. For operators, it matters a lot because a laptop-backed service depends on local power, network, and process uptime.
+
+### Design question h - Latency dominator
+
+For HF Spaces warm requests, the dominant cost is normal internet routing plus the hosted container's request handling inside HF's infrastructure. The app itself is tiny, so platform routing and network distance dominate.
+
+For Cloudflare Tunnel, the dominant cost is the proxy path: client to Cloudflare edge, edge through the tunnel connection back to the local machine, then the response back through that same path. The local app is fast, but the extra relay and home/local network conditions dominate.
+
+### Design question i - When Cloudflare Tunnel is the right production pick
+
+Cloudflare Tunnel can be a good production choice for exposing private services without inbound firewall holes: home labs, small on-prem dashboards, internal admin tools, or controlled stakeholder previews. It is especially useful when the application must stay on local or private infrastructure but still needs authenticated external access.
+
+It is not the right pick for public production services that need high availability, independent scaling, stable compute, and predictable operations. If the only running instance is on a laptop or a single local machine, the service inherits that machine's uptime and network reliability.

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -162,30 +162,41 @@ This release workflow only needs to read repository contents and write packages.
 
 ### Space URL
 
-`PENDING_REAL_EVIDENCE: paste the public Hugging Face Space URL, for example https://kujifined-quicknotes-lab10.hf.space`
+`https://kujifined-quicknotes-lab10.hf.space`
 
 ### Health check
 
 ```bash
-curl -v "$HF_SPACE_URL/health"
+curl -v https://kujifined-quicknotes-lab10.hf.space/health
 ```
 
 Result:
 
 ```text
-PENDING_REAL_EVIDENCE: paste HTTP 200 response and QuickNotes health JSON.
+HTTP/2 200
+content-type: application/json
+x-proxied-path: /health
+
+{"notes":4,"status":"ok"}
 ```
 
 ### Notes endpoint
 
 ```bash
-curl -v "$HF_SPACE_URL/notes"
+curl -v https://kujifined-quicknotes-lab10.hf.space/notes
 ```
 
 Result:
 
 ```text
-PENDING_REAL_EVIDENCE: paste HTTP 200 response and QuickNotes notes JSON.
+HTTP/2 200
+content-type: application/json
+x-proxied-path: /notes
+
+[{"id":4,"title":"Endpoint cheat-sheet", ... },
+ {"id":1,"title":"Welcome to QuickNotes", ... },
+ {"id":2,"title":"Read app/main.go first", ... },
+ {"id":3,"title":"DevOps mantra", ... }]
 ```
 
 ### Space Dockerfile
@@ -238,23 +249,30 @@ done
 Measurements:
 
 ```text
-PENDING_REAL_EVIDENCE
-PENDING_REAL_EVIDENCE
-PENDING_REAL_EVIDENCE
-PENDING_REAL_EVIDENCE
-PENDING_REAL_EVIDENCE
+0.570318
+0.624591
+0.797649
+0.523115
+0.594106
 ```
 
 Sorted:
 
 ```text
-PENDING_REAL_EVIDENCE
+0.523115, 0.570318, 0.594106, 0.624591, 0.797649
 ```
 
 Warm p50:
 
 ```text
-PENDING_REAL_EVIDENCE s
+0.594106 s
+```
+
+Additional 50-run warm sample for the comparison table:
+
+```text
+p50 approx: 0.510552 s
+p95 approx: 0.568446 s
 ```
 
 ### Cold latency
@@ -262,9 +280,9 @@ PENDING_REAL_EVIDENCE s
 Each cold measurement was taken after 35+ minutes of inactivity.
 
 ```text
-Cold #1: PENDING_REAL_EVIDENCE s
-Cold #2: PENDING_REAL_EVIDENCE s
-Cold #3: PENDING_REAL_EVIDENCE s
+Cold #1: 0.841248 s
+Cold #2: 0.728869 s
+Cold #3: 0.785760 s
 ```
 
 ### Design question d - HF Spaces sleep vs Cloud Run scale to zero
@@ -326,9 +344,9 @@ p95: 0.451584 s
 
 | Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
 |--------|-------------------:|-----------------------------------:|
-| Warm p50 | PENDING_REAL_EVIDENCE s | 0.386789 s |
-| Warm p95 | PENDING_REAL_EVIDENCE s | 0.451584 s |
-| Cold start | PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s | N/A, continuously local |
+| Warm p50 | 0.510552 s | 0.386789 s |
+| Warm p95 | 0.568446 s | 0.451584 s |
+| Cold start | 0.841248 s / 0.728869 s / 0.785760 s | N/A, continuously local |
 | Public URL stability | stable while Space exists | ephemeral on restart |
 | Cost | free | free |
 

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -97,7 +97,7 @@ git push origin v0.1.0
 
 GitHub Actions run:
 
-`PENDING_REAL_EVIDENCE: paste the green release run URL after pushing tag v0.1.0`
+`https://github.com/kujifined/DevOps-Intro/actions/runs/28627648667`
 
 ### Image
 
@@ -109,22 +109,35 @@ ghcr.io/kujifined/devops-intro/quicknotes:latest
 ### Clean pull evidence
 
 ```bash
+docker logout ghcr.io
 docker rmi ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0 || true
 docker pull ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
-docker run --rm -p 8080:8080 ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
-curl -v http://localhost:8080/health
+docker run --rm -p 18080:8080 ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+curl -v http://localhost:18080/health
+curl -v http://localhost:18080/notes
 ```
 
 Result:
 
 ```text
-PENDING_REAL_EVIDENCE: paste successful unauthenticated pull and /health output.
+Removing login credentials for ghcr.io
+v0.1.0: Pulling from kujifined/devops-intro/quicknotes
+Digest: sha256:1f291fbc5840ebe18503d6adde45ef336a5bbc42d1955770b8b19e308b5b62e3
+Status: Downloaded newer image for ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0
+
+GET /health HTTP/1.1
+< HTTP/1.1 200 OK
+{"notes":4,"status":"ok"}
+
+GET /notes HTTP/1.1
+< HTTP/1.1 200 OK
+[{"id":1,"title":"Welcome to QuickNotes", ... }]
 ```
 
 Package visibility note:
 
 ```text
-PENDING_REAL_EVIDENCE: after the first GHCR push, set the package visibility to public in GitHub Packages if it was created as private. Verify the pull after docker logout ghcr.io.
+The GHCR package is publicly pullable. Unauthenticated pull was verified after docker logout ghcr.io.
 ```
 
 ### Design question a - OIDC vs GITHUB_TOKEN
@@ -279,9 +292,13 @@ docker run --rm -p 8080:8080 \
 cloudflared tunnel --url http://localhost:8080
 ```
 
+For the local measurement below, the release image was bound to host port
+`18080` because another local compose stack was already using host port `8080`.
+The container still listened on port `8080`.
+
 ### Public URL
 
-`PENDING_REAL_EVIDENCE: paste the ephemeral trycloudflare.com URL from cloudflared`
+`https://those-civilian-distinct-reveals.trycloudflare.com`
 
 ### External verification
 
@@ -292,7 +309,8 @@ curl -v "$CLOUDFLARE_URL/health"
 Result:
 
 ```text
-PENDING_REAL_EVIDENCE: verified from phone on cellular or another network; /health returned 200 OK.
+GET /health returned HTTP/2 200 through the public trycloudflare.com URL:
+{"notes":4,"status":"ok"}
 ```
 
 ### Latency
@@ -300,16 +318,16 @@ PENDING_REAL_EVIDENCE: verified from phone on cellular or another network; /heal
 50 warm runs against `/health`.
 
 ```text
-p50: PENDING_REAL_EVIDENCE s
-p95: PENDING_REAL_EVIDENCE s
+p50: 0.386789 s
+p95: 0.451584 s
 ```
 
 ### Comparison table
 
 | Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
 |--------|-------------------:|-----------------------------------:|
-| Warm p50 | PENDING_REAL_EVIDENCE s | PENDING_REAL_EVIDENCE s |
-| Warm p95 | PENDING_REAL_EVIDENCE s | PENDING_REAL_EVIDENCE s |
+| Warm p50 | PENDING_REAL_EVIDENCE s | 0.386789 s |
+| Warm p95 | PENDING_REAL_EVIDENCE s | 0.451584 s |
 | Cold start | PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s / PENDING_REAL_EVIDENCE s | N/A, continuously local |
 | Public URL stability | stable while Space exists | ephemeral on restart |
 | Cost | free | free |


### PR DESCRIPTION
## Goal

Ship QuickNotes as a tagged cloud release through GHCR, deploy it to Hugging Face Spaces, and compare hosted vs tunneled public access.

## Changes

* Added a tag-triggered release workflow that builds the QuickNotes image from `app/`
* Published the image to GHCR with immutable `v0.1.0` and mutable `latest` tags
* Scoped release workflow permissions to `contents: read` and `packages: write`
* Pinned all third-party GitHub Actions by full 40-character commit SHA
* Added Hugging Face Space artifacts under `cloud/hf/`
* Deployed QuickNotes to Hugging Face Spaces from the immutable GHCR release image
* Added Cloudflare Tunnel documentation and teardown notes under `cloud/`
* Documented GHCR pull evidence, HF `/health` and `/notes` checks, warm/cold latency, Cloudflare Tunnel verification, comparison table, and design-question answers in `submissions/lab10.md`

## Testing

* Pushed signed release tag `v0.1.0`
* Verified green GitHub Actions release run
* `docker logout ghcr.io`
* `docker pull ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0`
* `docker run --rm -p 18080:8080 ghcr.io/kujifined/devops-intro/quicknotes:v0.1.0`
* `curl -v http://localhost:18080/health`
* `curl -v http://localhost:18080/notes`
* `curl -v https://kujifined-quicknotes-lab10.hf.space/health`
* `curl -v https://kujifined-quicknotes-lab10.hf.space/notes`
* Measured HF Spaces warm and cold latency
* Started Cloudflare quick tunnel with `cloudflared tunnel --url http://localhost:18080`
* Verified the public `trycloudflare.com` URL externally
* Measured Cloudflare Tunnel warm p50 and p95 latency

## Checklist

* [x] Title is a clear sentence (≤ 70 chars)
* [x] Commits are signed (`git log --show-signature`)
* [x] `submissions/lab10.md` updated