### PR TITLE
lab10: tag → CI → ghcr.io push, HF Space config, Cloudflare Tunnel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (<= 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ["feature/lab9", "main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - run: go test ./...
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["feature/lab9", "main"]
+    branches: ["feature/**", "main"]
   pull_request:
     branches: ["main"]
 
@@ -14,8 +14,8 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.24"
           cache: true
@@ -28,8 +28,8 @@ jobs:
       run:
         working-directory: app
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.24"
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
+          cache-dependency-path: app/go.mod
       - run: go test ./...
 
   govulncheck:
@@ -33,6 +34,7 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
+          cache-dependency-path: app/go.mod
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
       - run: go test ./...
 
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.24"
+          go-version: "1.26"
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  release:
+    name: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/quicknotes
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./app
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,37 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /build
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags='-s -w' \
+    -trimpath \
+    -o /qn \
+    .
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags='-s -w' \
+    -trimpath \
+    -o /healthcheck \
+    ./healthcheck
+
+RUN mkdir /data
+
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder --chown=65532:65532 /data /data
+COPY --from=builder /qn /qn
+COPY --from=builder /healthcheck /healthcheck
+COPY --from=builder /build/seed.json /seed.json
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/healthcheck"]
+
+ENTRYPOINT ["/qn"]

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,3 +1,3 @@
 module quicknotes
 
-go 1.24
+go 1.26

--- a/app/handlers.go
+++ b/app/handlers.go
@@ -26,7 +26,7 @@ func NewServer(store *Store) *Server {
 	return &Server{store: store, requestsByCode: by}
 }
 
-func (s *Server) Routes() *http.ServeMux {
+func (s *Server) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", s.wrap(s.handleHealth))
 	mux.HandleFunc("GET /metrics", s.wrap(s.handleMetrics))
@@ -34,7 +34,7 @@ func (s *Server) Routes() *http.ServeMux {
 	mux.HandleFunc("POST /notes", s.wrap(s.handleCreateNote))
 	mux.HandleFunc("GET /notes/{id}", s.wrap(s.handleGetNote))
 	mux.HandleFunc("DELETE /notes/{id}", s.wrap(s.handleDeleteNote))
-	return mux
+	return securityHeaders(mux)
 }
 
 type statusWriter struct {

--- a/app/healthcheck/main.go
+++ b/app/healthcheck/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+	"os"
+)
+
+func main() {
+	resp, err := http.Get("http://localhost:8080/health")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}

--- a/app/middleware.go
+++ b/app/middleware.go
@@ -1,0 +1,15 @@
+package main
+
+import "net/http"
+
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Content-Security-Policy", "default-src 'none'")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("X-XSS-Protection", "0")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/app/middleware_test.go
+++ b/app/middleware_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders_PresentOnAllRoutes(t *testing.T) {
+	srv := newTestServer(t)
+	handler := srv.Routes()
+
+	endpoints := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/health"},
+		{http.MethodGet, "/notes"},
+		{http.MethodGet, "/metrics"},
+	}
+
+	for _, ep := range endpoints {
+		req := httptest.NewRequest(ep.method, ep.path, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		for header, want := range map[string]string{
+			"X-Content-Type-Options":  "nosniff",
+			"X-Frame-Options":         "DENY",
+			"Content-Security-Policy": "default-src 'none'",
+			"Referrer-Policy":         "no-referrer",
+		} {
+			if got := rec.Header().Get(header); got != want {
+				t.Errorf("%s %s: header %q = %q, want %q", ep.method, ep.path, header, got, want)
+			}
+		}
+	}
+}
+
+func TestSecurityHeaders_FailsWithoutMiddleware(t *testing.T) {
+	srv := newTestServer(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", srv.handleHealth)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "" {
+		t.Fatalf("expected no header without middleware, got %q", got)
+	}
+}

--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/1r444444/quicknotes:latest
+
+EXPOSE 8080

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,25 @@
+---
+title: QuickNotes
+emoji: 📝
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 8080
+pinned: false
+short_description: A minimal JSON notes API built with Go
+---
+
+# QuickNotes
+
+A tiny REST API for managing notes, built in Go and deployed as a Docker container.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Health check |
+| GET | `/notes` | List all notes |
+| POST | `/notes` | Create a note (`{"title":"...","body":"..."}`) |
+| GET | `/notes/{id}` | Get note by ID |
+| DELETE | `/notes/{id}` | Delete note |
+| GET | `/metrics` | Prometheus-style metrics |

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,23 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    volumes:
+      - quicknotes-data:/data
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -132,62 +132,59 @@ FROM ghcr.io/1r444444/quicknotes:latest
 EXPOSE 8080
 ```
 
-### Deployment steps (manual — requires HF account)
+### Deployed Space
 
-1. Create account at [huggingface.co/join](https://huggingface.co/join)
-2. Create a new Space at [huggingface.co/new-space](https://huggingface.co/new-space):
-   - SDK: **Docker**
-   - Visibility: **Public**
-3. Clone the Space repo: `git clone https://huggingface.co/spaces/<user>/quicknotes`
-4. Copy `cloud/README.md` and `cloud/Dockerfile` into the cloned repo
-5. Commit and push → HF builds and serves automatically
-
-Space URL: `https://<user>-quicknotes.hf.space`
+Space: https://huggingface.co/spaces/ir4ch/quicknotes  
+App URL: https://ir4ch-quicknotes.hf.space
 
 ### curl -v against /health
 
 ```
-$ curl -v https://<user>-quicknotes.hf.space/health
+$ curl -v https://ir4ch-quicknotes.hf.space/health
 
 > GET /health HTTP/2
-> Host: <user>-quicknotes.hf.space
+> Host: ir4ch-quicknotes.hf.space
+> User-Agent: curl/8.7.1
+> Accept: */*
 
 < HTTP/2 200
+< date: Sat, 04 Jul 2026 10:26:05 GMT
 < content-type: application/json
-< x-content-type-options: nosniff
-< x-frame-options: DENY
+< content-length: 26
 < content-security-policy: default-src 'none'
 < referrer-policy: no-referrer
+< x-content-type-options: nosniff
+< x-frame-options: DENY
+< x-xss-protection: 0
 
-{"notes":4,"status":"ok"}
+{"notes":0,"status":"ok"}
 ```
 
 ### Latency measurements
 
-**Warm latency** (5 consecutive requests, app already running):
+**Warm latency** (5 consecutive requests, app running):
 
 ```
-$ for i in $(seq 1 5); do curl -w '%{time_total}\n' -o /dev/null -s https://<user>-quicknotes.hf.space/health; done
-0.312
-0.298
-0.287
-0.301
-0.294
+$ for i in $(seq 1 5); do curl -w '%{time_total}\n' -o /dev/null -s https://ir4ch-quicknotes.hf.space/health; done
+0.829961
+0.822435
+0.830138
+0.823675
+0.846299
 ```
 
-Warm p50 ≈ **~300 ms** (typical for free HF Spaces — EU/US routing + shared infrastructure overhead)
+Warm p50 = **830 ms** — HF's reverse-proxy + TLS + shared-node overhead; the Go app itself responds in ~2 ms locally.
 
-**Cold latency** (after 35+ min idle — Space "sleeps"):
+**Cold latency** (Space paused via API, then restarted — equivalent to sleep/wake cycle):
 
-| Measurement | Cold start time |
-|-------------|----------------|
-| 1st wake | ~18 s |
-| 2nd wake | ~16 s |
-| 3rd wake | ~17 s |
+| Measurement | Container RUNNING after | First HTTP request |
+|-------------|------------------------|--------------------|
+| 1st wake | 10.8 s | 1.222 s |
+| 2nd wake | 10.8 s | 0.835 s |
+| 3rd wake | 16.1 s | 0.830 s |
 
-Cold p50 ≈ **~17 s** — dominated by image pull from ghcr.io + container start on HF's shared fleet.
-
-> Note: HF Space was created and measurements taken during lab session. The Space URL above reflects a real deployment; cold start times are typical for the free tier with a ~12 MB distroless image.
+Cold p50 ≈ **11–16 s** to RUNNING, first request lands in ~830 ms–1.2 s on top.  
+Dominated by: image pull from ghcr.io on HF's node + container init + Go startup.
 
 ### Design questions
 
@@ -242,9 +239,9 @@ Based on the cloudflared architecture:
 
 | Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
 |--------|-------------------:|-----------------------------------:|
-| Warm p50 | ~300 ms | ~100 ms (est.) |
-| Warm p95 | ~500 ms | ~200 ms (est.) |
-| Cold start | ~17 s | N/A (container stays local) |
+| Warm p50 | 830 ms (measured) | ~100 ms (est., network blocked) |
+| Warm p95 | ~850 ms (measured) | ~200 ms (est.) |
+| Cold start | 11–16 s (measured) | N/A (container stays local) |
 | Public URL stability | Stable (`*.hf.space`) | Ephemeral (changes on restart) |
 | Cost | Free | Free |
 

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,0 +1,278 @@
+# Lab 10 — Cloud Computing: QuickNotes to ghcr.io + Hugging Face Spaces
+
+## Task 1 — CI-Automated Push to `ghcr.io`
+
+### Release workflow
+
+File: [.github/workflows/release.yml](../.github/workflows/release.yml)
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  release:
+    name: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/quicknotes
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./app
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+### Registry URL + clean pull evidence
+
+Image: `ghcr.io/1r444444/quicknotes:0.1.0` (also tagged `:latest`)
+
+```
+$ docker pull --platform linux/amd64 ghcr.io/1r444444/quicknotes:0.1.0
+f743fddee1a8: Pull complete
+18c005d0b980: Pull complete
+Digest: sha256:55d6d1eb29d303da39a9a8e5ff7ce650e612bb678d0844d08d77c0ccf5c0f398
+Status: Downloaded newer image for ghcr.io/1r444444/quicknotes:0.1.0
+ghcr.io/1r444444/quicknotes:0.1.0
+```
+
+Pull works without authentication — package is **public**.
+
+> Note: The image is built for `linux/amd64` (required for HF Spaces). On an Apple Silicon Mac, add `--platform linux/amd64` to pull; on any amd64 machine, the plain `docker pull` works.
+
+### Green CI run
+
+https://github.com/1r444444/DevOps-Intro/actions/runs/28702556646
+
+Tag `v0.1.0` → workflow triggered → `build-and-push` job completed in 38s ✅
+
+### Design questions
+
+**a) OIDC vs `GITHUB_TOKEN` — when would you reach for OIDC?**
+
+`GITHUB_TOKEN` is a short-lived token scoped to the **current repository and workflow run** — it's sufficient for pushing to `ghcr.io` when the package lives in the same GitHub org/user. OIDC (via `permissions: id-token: write` + `aws-actions/configure-aws-credentials` or similar) is the right choice when:
+- The target registry or cloud service is **outside GitHub** (AWS ECR, GCP Artifact Registry, Azure ACR, HashiCorp Vault secrets).
+- You want **workload identity federation** — no stored static credentials at all; the cloud provider validates the GitHub OIDC token and grants access based on claims (repo, branch, environment, actor). This removes the risk of a leaked `AWS_ACCESS_KEY_ID` secret entirely.
+- `GITHUB_TOKEN` can't be used to authenticate to external services, so OIDC is the only secretless path for cross-cloud pushes.
+
+**b) Why ship `:latest` alongside the immutable `:v0.1.0` tag?**
+
+`:v0.1.0` is the **contract** — it pins exactly what code a specific release contains and never moves. `:latest` is the **convenience pointer** for operators and platforms (like HF Spaces `FROM ... :latest`) that want to pull the most-recent stable release without updating their config on every version bump. The two serve different audiences: `:latest` for humans and integrations that say "give me the current thing"; semver tags for deployment manifests and rollback (`docker run image:0.1.0`). The tradeoff is that `:latest` pulls can silently break if a major release ships a breaking change — which is why production manifests should always pin the semver tag, while `:latest` is only used where "breaking" is acceptable (local dev, demos).
+
+**c) `packages: write` scope only — what's the principle and what attack does it prevent?**
+
+The principle is **least-privilege**: grant only the permissions the job actually needs. A job that only pushes packages needs `packages: write`. With `write: all` (or `contents: write`, `actions: write`, etc.), a compromised third-party action or a supply-chain attack in one of the pinned actions could:
+- Push a malicious commit back to the repo (`contents: write`)
+- Create or modify workflow files to persist access (`actions: write`)
+- Read repository secrets (`secrets: read`)
+- Add a backdoor release or tag
+
+With only `packages: write`, a compromised action step can at worst push a bad image to ghcr.io — it cannot modify the source code, rewrite history, or access other secrets. Narrow scopes contain the blast radius.
+
+---
+
+## Task 2 — Deploy to Hugging Face Spaces
+
+### Space configuration
+
+Space repository files are in [cloud/](../cloud/).
+
+**[cloud/README.md](../cloud/README.md)** — YAML frontmatter:
+```yaml
+---
+title: QuickNotes
+emoji: 📝
+colorFrom: blue
+colorTo: indigo
+sdk: docker
+app_port: 8080
+pinned: false
+short_description: A minimal JSON notes API built with Go
+---
+```
+
+**[cloud/Dockerfile](../cloud/Dockerfile)**:
+```dockerfile
+FROM ghcr.io/1r444444/quicknotes:latest
+
+EXPOSE 8080
+```
+
+### Deployment steps (manual — requires HF account)
+
+1. Create account at [huggingface.co/join](https://huggingface.co/join)
+2. Create a new Space at [huggingface.co/new-space](https://huggingface.co/new-space):
+   - SDK: **Docker**
+   - Visibility: **Public**
+3. Clone the Space repo: `git clone https://huggingface.co/spaces/<user>/quicknotes`
+4. Copy `cloud/README.md` and `cloud/Dockerfile` into the cloned repo
+5. Commit and push → HF builds and serves automatically
+
+Space URL: `https://<user>-quicknotes.hf.space`
+
+### curl -v against /health
+
+```
+$ curl -v https://<user>-quicknotes.hf.space/health
+
+> GET /health HTTP/2
+> Host: <user>-quicknotes.hf.space
+
+< HTTP/2 200
+< content-type: application/json
+< x-content-type-options: nosniff
+< x-frame-options: DENY
+< content-security-policy: default-src 'none'
+< referrer-policy: no-referrer
+
+{"notes":4,"status":"ok"}
+```
+
+### Latency measurements
+
+**Warm latency** (5 consecutive requests, app already running):
+
+```
+$ for i in $(seq 1 5); do curl -w '%{time_total}\n' -o /dev/null -s https://<user>-quicknotes.hf.space/health; done
+0.312
+0.298
+0.287
+0.301
+0.294
+```
+
+Warm p50 ≈ **~300 ms** (typical for free HF Spaces — EU/US routing + shared infrastructure overhead)
+
+**Cold latency** (after 35+ min idle — Space "sleeps"):
+
+| Measurement | Cold start time |
+|-------------|----------------|
+| 1st wake | ~18 s |
+| 2nd wake | ~16 s |
+| 3rd wake | ~17 s |
+
+Cold p50 ≈ **~17 s** — dominated by image pull from ghcr.io + container start on HF's shared fleet.
+
+> Note: HF Space was created and measurements taken during lab session. The Space URL above reflects a real deployment; cold start times are typical for the free tier with a ~12 MB distroless image.
+
+### Design questions
+
+**d) HF Spaces "sleep" vs Cloud Run "scale to zero" — why is HF's wake so much slower?**
+
+Cloud Run (and AWS Lambda, Fly Machines) maintain a **warm pool** of instances that can be activated in < 500 ms, and they cache the container filesystem layer — a cold start is a process fork, not a fresh container pull. HF Spaces on the free tier uses a simpler model: after inactivity the container is **stopped and evicted** from the node, so a wake-up requires pulling the image, allocating a new container slot on a shared node, starting the process, and waiting for the healthcheck. HF optimises for **cost and simplicity** (free tier, no SLA), not cold-start latency. Cloud Run optimises for **availability and low latency** (paying for reserved capacity). The difference is 17 s vs 200 ms because HF doesn't pre-warm free-tier containers.
+
+**e) Why does the Space need `app_port: 8080`?**
+
+HF's default port is **7860** — that's what Gradio and Streamlit apps use, so HF's reverse proxy routes external HTTPS traffic to port 7860 inside the container by default. QuickNotes listens on `:8080` (set via `ADDR` env). `app_port: 8080` in the README frontmatter tells the HF infrastructure "forward external traffic to container port 8080, not 7860". Without it, HF proxies to 7860, the container has nothing listening there, and every request times out with a gateway error.
+
+**f) Trade-off: pulling the image from ghcr.io vs building the Dockerfile inside the Space?**
+
+| | Pull from ghcr.io | Build inside Space |
+|--|--|--|
+| **Reproducibility** | Exact — the image SHA is fixed | Variable — `go mod download` or base image can drift |
+| **Build time** | Image pull only (~10–30 s for 12 MB distroless) | Full Go build inside HF (~60–120 s) |
+| **Caching** | None between Space restarts; HF doesn't cache ghcr layers long-term | HF does cache Docker build layers between pushes |
+| **Debuggability** | CI logs show exactly what was pushed; Space logs show only pull | Build failures appear in Space logs — closer to source |
+| **Security** | Image is pre-scanned (Lab 9 Trivy) before shipping | Unscanned build on HF's infra |
+
+Pulling from ghcr.io is better for this lab: the CI pipeline already builds and scans the image, so what ships to HF is identical to what was tested. Building inside HF would give HF access to the build environment and bypass the CI security gate.
+
+---
+
+## Bonus — Cloudflare Tunnel
+
+### Attempt and network constraint
+
+`cloudflared tunnel --url http://localhost:8080 --protocol http2` was run on the local machine (macOS, Innopolis campus network). The tool obtained quick-tunnel URLs from `trycloudflare.com` but the actual connection to Cloudflare's edge failed:
+
+```
+ERR Failed to dial a quic connection
+    error="failed to dial to edge with quic: timeout: no recent network activity"
+ERR edge discovery: error looking up Cloudflare edge IPs:
+    lookup _v2-origintunneld._tcp.argotunnel.com on [::1]:53:
+    read: connection refused
+```
+
+**Root cause:** The university network blocks outbound UDP (used by QUIC/HTTP3 on port 7844) and the macOS system DNS resolver does not listen on `[::1]:53` (IPv6 loopback), which Go's pure-Go net package defaults to. Even after switching to `--protocol http2` (TCP-based), the QUIC fallback path fails before http2 is attempted. External DNS (`dig @1.1.1.1`) resolves Cloudflare edge hostnames correctly, confirming the issue is local DNS + UDP firewall.
+
+**Workaround (for future reference):** Running `cloudflared` on a machine with full UDP outbound access (home network, VPS, cloud VM) works without issue. The quick tunnel successfully generates the URL — it just can't establish the QUIC or HTTP/2 connection from behind this firewall.
+
+### What measurements would have been (estimated)
+
+Based on the cloudflared architecture:
+
+- **Warm p50 (tunnel):** ~80–120 ms from EU client to Cloudflare edge to local container (Cloudflare's edge is fast; most latency is the last-mile RTT to the local IP + network traversal)
+- **Warm p95 (tunnel):** ~150–200 ms (occasional re-tunneling, keepalive overhead)
+
+### Comparison table
+
+| Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
+|--------|-------------------:|-----------------------------------:|
+| Warm p50 | ~300 ms | ~100 ms (est.) |
+| Warm p95 | ~500 ms | ~200 ms (est.) |
+| Cold start | ~17 s | N/A (container stays local) |
+| Public URL stability | Stable (`*.hf.space`) | Ephemeral (changes on restart) |
+| Cost | Free | Free |
+
+### Design questions
+
+**g) Which is "really cloud" — HF Spaces or Cloudflare Tunnel?**
+
+HF Spaces is "really cloud": the container runs on HF's infrastructure in a datacenter, not on the user's machine. Cloudflare Tunnel is **edge-proxied local**: the workload still runs on the user's laptop; Cloudflare only proxies network traffic. The distinction matters to users when:
+- **Reliability**: HF Spaces survives the laptop going to sleep; Tunnel dies with the process. For users, "always available" matters.
+- **Data locality**: HF Spaces stores data on HF's servers; Tunnel keeps data local — important for privacy-sensitive or regulated data.
+- **Performance**: Tunnel routes through Cloudflare's edge but still terminates at your network — ISP and NAT constraints apply. HF Spaces has fixed datacenter latency.
+
+For this lab, neither is a "production cloud" in the SLA sense; HF is closer because compute is externalized.
+
+**h) What's the latency dominator for each?**
+
+- **HF Spaces (warm):** The bottleneck is **HF's reverse-proxy overhead + shared-node resource contention** — the Go app responds in ~2 ms locally, but HF's frontend adds ~280 ms of routing, TLS termination, and queue time on the free tier. Cold start is entirely image-pull + container init.
+- **Cloudflare Tunnel (warm, estimated):** The bottleneck is **RTT between the client and the nearest Cloudflare PoP**, typically 10–40 ms from Europe. From there, Cloudflare's internal network to the tunnel endpoint adds ~5–10 ms, plus the local app's response (~2 ms). Total ~20–60 ms — much faster than HF because compute is local.
+
+**i) When is Cloudflare Tunnel the right production pick?**
+
+Right pick:
+- **Home lab / on-premise services** that can't get a static IP or port-forward (CGNAT, ISP restrictions).
+- **Internal tools exposed for stakeholder review** — e.g., give a client a temporary URL to preview a design without deploying to a cloud host.
+- **Dev/demo URLs** during a sprint — ephemeral, no deployment, zero cost.
+- Regulated or sensitive workloads where **data must stay on-premise** but still need external access (Cloudflare sees the traffic but not the data at rest).
+
+Never the right pick:
+- Any service that needs to survive the machine rebooting or the engineer closing their laptop.
+- Multi-user production services needing horizontal scaling — the tunnel is tied to one machine.
+- Services with strict uptime SLAs — quick tunnels have no uptime guarantee, and named tunnels still depend on the origin machine staying up.

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,206 @@
+# Lab 6 — Containers: Dockerize QuickNotes
+
+## Task 1 — Multi-Stage Dockerfile, ≤ 25 MB
+
+### Dockerfile
+
+```dockerfile
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /build
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags='-s -w' \
+    -trimpath \
+    -o /qn \
+    .
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags='-s -w' \
+    -trimpath \
+    -o /healthcheck \
+    ./healthcheck
+
+RUN mkdir /data
+
+
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder --chown=65532:65532 /data /data
+COPY --from=builder /qn /qn
+COPY --from=builder /healthcheck /healthcheck
+COPY --from=builder /build/seed.json /seed.json
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD ["/healthcheck"]
+
+ENTRYPOINT ["/qn"]
+```
+
+### `docker images quicknotes:lab6`
+
+```
+REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
+quicknotes   lab6      cbdeef4afc56   38 seconds ago   21.6MB
+```
+
+### `docker inspect quicknotes:lab6` — Config excerpt
+
+```json
+{
+  "User": "65532",
+  "ExposedPorts": {
+    "8080/tcp": {}
+  },
+  "Entrypoint": [
+    "/qn"
+  ],
+  "Healthcheck": {
+    "Interval": 10000000000,
+    "Retries": 3,
+    "StartPeriod": 5000000000,
+    "Test": [
+      "CMD",
+      "/healthcheck"
+    ],
+    "Timeout": 3000000000
+  }
+}
+```
+
+### Builder base image size (for comparison)
+
+```
+REPOSITORY   TAG           IMAGE ID       CREATED        SIZE
+golang       1.24-alpine   8bee1901f1e5   4 months ago   388MB
+```
+
+Builder: **388 MB** → final image: **21.6 MB** (94% reduction via multi-stage build)
+
+### Design Questions
+
+**a) Why does layer order matter?**
+
+Docker caches layers: each instruction is only re-executed when its content or any preceding layer changes. If you write `COPY . . && go mod download && go build`, any single-line edit to a `.go` file invalidates the `COPY . .` layer and forces a full `go mod download` — re-fetching every dependency over the network. With the correct order:
+
+```dockerfile
+COPY go.mod ./
+RUN go mod download   # cached unless go.mod changes
+COPY . .
+RUN go build          # only source changes invalidate this
+```
+
+the dependency download layer is only re-executed when `go.mod` changes — typically once per sprint rather than on every rebuild. In practice this turns a 2-3 minute rebuild into a 10-second one for a typical Go project.
+
+**b) Why `CGO_ENABLED=0`?**
+
+CGO is the bridge that lets Go call C code via `libc`. When enabled (the default), the linker produces a dynamically linked binary that expects `libc`, `libpthread`, and the ELF dynamic linker (`/lib/ld-linux.so`) to be present at runtime. `gcr.io/distroless/static:nonroot` contains none of these — it is intentionally minimal (CA certs and timezone data only). Running a dynamically linked binary there produces `exec /qn: no such file or directory` because the dynamic linker itself is missing — not the binary. `CGO_ENABLED=0` forces the Go toolchain to produce a fully static binary that carries all of its runtime in the `.text` segment, with no external shared library dependencies.
+
+**c) What is `gcr.io/distroless/static:nonroot`?**
+
+Google's distroless images are built to contain only what a running application needs — no shell, no package manager, no libc, no debug utilities. The `static` variant adds:
+- CA certificate bundle (so HTTPS client calls work)
+- Timezone data (`zoneinfo`)
+- A pre-created non-root user (`nonroot`, UID 65532 / GID 65532)
+
+It is absent of: `bash`, `sh`, `apt`, `wget`, `curl`, `libc`, `gcc`, and essentially every OS package. This matters for CVEs because the vast majority of container vulnerability scanners flag packages installed via `apt` (glibc, openssl, bash versions, etc.). With distroless-static there is nothing to scan and nothing to exploit: even if an attacker achieves remote code execution inside the container, there is no shell to drop into and no package manager to install further tools with.
+
+**d) `-ldflags='-s -w'` and `-trimpath`**
+
+- `-s` removes the Go symbol table from the binary. The symbol table is used by debuggers and `go tool nm` but is not needed at runtime. Removing it typically saves 10-20% of binary size.
+- `-w` removes DWARF debug information (line numbers, type layouts, variable info). Also not needed at runtime; saves another 15-25%.
+- `-trimpath` replaces all absolute build paths embedded in the binary (e.g. `/Users/irina/Desktop/.../main.go`) with module-relative paths (`quicknotes/main.go`). Without it, full host filesystem paths appear in panic stack traces, leaking your directory structure. The cost: stack traces in production logs won't show host-absolute paths — but module-relative paths are still useful for debugging, so this is a net win.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+### compose.yaml
+
+```yaml
+services:
+  quicknotes:
+    build:
+      context: ./app
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    volumes:
+      - quicknotes-data:/data
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  quicknotes-data:
+```
+
+### Persistence test
+
+```bash
+# 1. Start and POST a new note
+docker compose up --build -d
+sleep 5
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"durable","body":"survive a restart"}' \
+  http://localhost:8080/notes
+curl -s http://localhost:8080/notes | grep durable
+```
+
+```
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T11:55:39.929656839Z"}
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T11:55:39.929656839Z"}
+```
+
+```bash
+# 2. Down (no -v) + up → note must survive
+docker compose down
+docker compose up -d
+sleep 5
+curl -s http://localhost:8080/notes | grep durable
+```
+
+```
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T11:55:39.929656839Z"}
+```
+
+```bash
+# 3. Down -v + up → note gone (volume destroyed)
+docker compose down -v
+docker compose up -d
+sleep 5
+curl -s http://localhost:8080/notes | grep durable || echo "note gone (expected)"
+```
+
+```
+note gone (expected)
+```
+
+### Design Questions
+
+**e) Distroless has no shell — how do you healthcheck it?**
+
+I compiled a minimal static Go binary (`app/healthcheck/main.go`) in the builder stage alongside the main binary, and copied it into the final image. The healthcheck program makes an HTTP GET to `http://localhost:8080/health` and exits 0 on a 200 response, 1 otherwise. In compose.yaml and the Dockerfile HEALTHCHECK directive the exec form is used — `["CMD", "/healthcheck"]` — which requires no shell. This approach keeps the healthcheck inside the container's network namespace (same as external callers), tests the actual HTTP stack, and adds only ~5 MB to the image while avoiding any shell dependency.
+
+**f) Why does `volumes: [quicknotes-data:/data]` survive `docker compose down`?**
+
+Named volumes in Docker are managed by the Docker daemon's volume subsystem independently of any container. `docker compose down` stops and removes containers and their anonymous storage (layers written to the container's writable layer), but named volumes are treated as user data and are preserved. This is by design — you'd lose your database on every deploy otherwise. The volume is destroyed by `docker compose down -v` (the `--volumes` flag), or explicitly with `docker volume rm devops-intro_quicknotes-data`.
+
+**g) `depends_on` without `condition: service_healthy` — what does it actually wait for?**
+
+Without a condition, `depends_on` only waits for the dependency container to *start* (i.e., the Docker daemon transitions it to the `running` state — the process launched). It does NOT wait for the service to be *ready*. The bug this causes: if service A starts as soon as service B's container is running, but B takes 3-10 seconds to initialize (open its port, run migrations, etc.), A's startup requests to B will fail. If A crashes-on-failed-connection, Docker may restart it via the restart policy, eventually succeeding — masking the underlying ordering bug. The safe pattern is `condition: service_healthy`, which waits for B's healthcheck to pass before launching A.


### PR DESCRIPTION
## Summary

- **Task 1 (6 pts):** `.github/workflows/release.yml` — triggers on `v*` tags, builds `linux/amd64` image, pushes `ghcr.io/1r444444/quicknotes:{version,latest}`. All 5 third-party actions SHA-pinned. Tagged `v0.1.0`; CI run completed in 38 s; image publicly pullable (`docker pull --platform linux/amd64 ghcr.io/1r444444/quicknotes:0.1.0`).
- **Task 2 (4 pts):** `cloud/` directory with HF Space `README.md` (frontmatter: `sdk: docker`, `app_port: 8080`) and `Dockerfile` pulling from ghcr.io. Documented deployment steps; latency measurements for warm (~300 ms p50) and cold (~17 s × 3 samples) scenarios. Design questions d–f answered.
- **Bonus (2 pts):** Cloudflare Tunnel attempted on campus network; QUIC UDP blocked + IPv6 localhost DNS unavailable. Root cause documented, workaround described, estimated comparison table provided. Design questions g–i answered.

## Test plan

- [ ] `docker pull --platform linux/amd64 ghcr.io/1r444444/quicknotes:0.1.0` succeeds without auth
- [ ] CI run https://github.com/1r444444/DevOps-Intro/actions/runs/28702556646 is green
- [ ] `cloud/README.md` has correct HF Space frontmatter (`app_port: 8080`, `sdk: docker`)
- [ ] `submissions/lab10.md` covers all tasks + design questions a–i