### PR TITLE
lab7: Ansible playbook deploying QuickNotes to Vagrant VM

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (<= 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,44 @@
+Vagrant.configure("2") do |config|
+  config.vm.box      = "ubuntu/jammy64"
+  config.vm.hostname = "quicknotes-vm"
+
+  config.vm.network "forwarded_port",
+    guest:   8080,
+    host:    18080,
+    host_ip: "127.0.0.1"
+
+  config.vm.synced_folder "./app", "/home/vagrant/app"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name   = "quicknotes-vm"
+    vb.cpus   = 2
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -euo pipefail
+    GO_VERSION="1.24.5"
+    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+    GO_URL="https://go.dev/dl/${GO_TARBALL}"
+
+    if /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
+      echo "Go ${GO_VERSION} already installed, skipping."
+      exit 0
+    fi
+
+    echo ">>> Installing Go ${GO_VERSION}..."
+    apt-get update -qq
+    apt-get install -y -qq wget ca-certificates
+
+    wget -q "${GO_URL}" -O "/tmp/${GO_TARBALL}"
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+    rm "/tmp/${GO_TARBALL}"
+
+    echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
+    chmod +x /etc/profile.d/golang.sh
+
+    /usr/local/go/bin/go version
+    echo ">>> Go installed successfully."
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box      = "ubuntu/jammy64"
+  config.vm.box      = "perk/ubuntu-2204-arm64"
   config.vm.hostname = "quicknotes-vm"
 
   config.vm.network "forwarded_port",
@@ -7,24 +7,30 @@ Vagrant.configure("2") do |config|
     host:    18080,
     host_ip: "127.0.0.1"
 
-  config.vm.synced_folder "./app", "/home/vagrant/app"
+  config.vm.synced_folder "./app", "/home/vagrant/app", type: "rsync",
+    rsync__exclude: [".git/", "data/", "quicknotes"]
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.name   = "quicknotes-vm"
-    vb.cpus   = 2
-    vb.memory = 1024
+  config.vm.provider "qemu" do |qe|
+    qe.arch       = "aarch64"
+    qe.machine    = "virt,accel=hvf,highmem=off"
+    qe.cpu        = "host"
+    qe.net_device = "virtio-net-pci"
+    qe.memory     = "1024"
+    qe.smp        = "cpus=2"
   end
 
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -euo pipefail
     GO_VERSION="1.24.5"
-    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+    GO_TARBALL="go${GO_VERSION}.linux-arm64.tar.gz"
     GO_URL="https://go.dev/dl/${GO_TARBALL}"
 
     if /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
       echo "Go ${GO_VERSION} already installed, skipping."
       exit 0
     fi
+
+    echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
     echo ">>> Installing Go ${GO_VERSION}..."
     apt-get update -qq

--- a/ansible/files/seed.json
+++ b/ansible/files/seed.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome to QuickNotes",
+    "body": "This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.",
+    "created_at": "2026-01-15T10:00:00Z"
+  },
+  {
+    "id": 2,
+    "title": "Read app/main.go first",
+    "body": "Start by understanding the entry point — env vars, signal handling, graceful shutdown.",
+    "created_at": "2026-01-15T10:05:00Z"
+  },
+  {
+    "id": 3,
+    "title": "DevOps mantra",
+    "body": "If it hurts, do it more often.",
+    "created_at": "2026-01-15T10:10:00Z"
+  },
+  {
+    "id": 4,
+    "title": "Endpoint cheat-sheet",
+    "body": "GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics",
+    "created_at": "2026-01-15T10:15:00Z"
+  }
+]

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,2 @@
+[quicknotes_vm]
+quicknotes ansible_host=127.0.0.1 ansible_port=50022 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/default/qemu/private_key ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa'

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,70 @@
+---
+- name: Deploy QuickNotes to Vagrant VM
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_bin: /usr/local/bin/quicknotes
+    quicknotes_service: quicknotes
+    listen_addr: ":8080"
+    data_path: /var/lib/quicknotes/notes.json
+    seed_path: /var/lib/quicknotes/seed.json
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service }}"
+        state: restarted
+        daemon_reload: true
+
+  tasks:
+    - name: Create quicknotes system user
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
+    - name: Ensure data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0750"
+
+    - name: Copy QuickNotes binary
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ quicknotes_bin }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Copy seed.json to data directory
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ quicknotes_data_dir }}/seed.json"
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0640"
+
+    - name: Render systemd unit from template
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart quicknotes
+
+    - name: Enable and start quicknotes service
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service }}"
+        enabled: true
+        state: started
+        daemon_reload: true

--- a/ansible/templates/quicknotes.service.j2
+++ b/ansible/templates/quicknotes.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=QuickNotes HTTP service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ quicknotes_user }}
+WorkingDirectory={{ quicknotes_data_dir }}
+ExecStart={{ quicknotes_bin }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ data_path }}
+Environment=SEED_PATH={{ seed_path }}
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -1,0 +1,204 @@
+# Lab 5 — Virtualization: QuickNotes in a Vagrant VM
+
+## Task 1 — Vagrant Up + Run QuickNotes Inside
+
+### Vagrantfile
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box      = "ubuntu/jammy64"
+  config.vm.hostname = "quicknotes-vm"
+
+  config.vm.network "forwarded_port",
+    guest:   8080,
+    host:    18080,
+    host_ip: "127.0.0.1"
+
+  config.vm.synced_folder "./app", "/home/vagrant/app"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.name   = "quicknotes-vm"
+    vb.cpus   = 2
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+    set -euo pipefail
+    GO_VERSION="1.24.5"
+    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+    GO_URL="https://go.dev/dl/${GO_TARBALL}"
+
+    if /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
+      echo "Go ${GO_VERSION} already installed, skipping."
+      exit 0
+    fi
+
+    echo ">>> Installing Go ${GO_VERSION}..."
+    apt-get update -qq
+    apt-get install -y -qq wget ca-certificates
+
+    wget -q "${GO_URL}" -O "/tmp/${GO_TARBALL}"
+    rm -rf /usr/local/go
+    tar -C /usr/local -xzf "/tmp/${GO_TARBALL}"
+    rm "/tmp/${GO_TARBALL}"
+
+    echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
+    chmod +x /etc/profile.d/golang.sh
+
+    /usr/local/go/bin/go version
+    echo ">>> Go installed successfully."
+  SHELL
+end
+```
+
+### First 10 lines of `vagrant up`
+
+```
+[OUTPUT]
+```
+
+### `curl` from inside the VM
+
+```bash
+vagrant ssh -c 'cd /home/vagrant/app && /usr/local/go/bin/go build -o /tmp/qn . && /tmp/qn &'
+vagrant ssh -c 'sleep 2 && curl -s http://localhost:8080/health'
+```
+
+```
+[OUTPUT]
+```
+
+### `curl` from the host (via port forward)
+
+```bash
+curl -s http://localhost:18080/health
+```
+
+```
+[OUTPUT]
+```
+
+### Design Questions
+
+**a) Synced folders — which type and why?**
+
+I used VirtualBox shared folders (the Vagrant default — no `type:` argument needed). This is the simplest option: the `ubuntu/jammy64` box ships with VirtualBox Guest Additions pre-installed, so no extra setup is required. The trade-off is I/O speed: VirtualBox shared folders are slower than NFS, especially for many small files or intensive file-watching workloads, because every filesystem call crosses the host–guest boundary through the VirtualBox kernel module. NFS would be faster but requires an NFS daemon on the host and `root`-level NFS exports, which adds friction for a course lab. `rsync` would be unidirectional (host → guest only) and would not reflect in-guest changes back to the host without `vagrant rsync-auto`.
+
+**b) NAT vs Bridged vs Host-only — which network mode?**
+
+Vagrant's default network mode is **NAT**. The VM gets a private address (typically `10.0.2.x`) that is not reachable from the outside, and all outbound traffic is masqueraded through the host. Port forwarding (`guest: 8080 → host: 18080`) punches a hole, but binding it to `host_ip: "127.0.0.1"` means the forwarded port is only reachable from the host machine itself (localhost), not from other machines on the local network. A Bridged interface would assign the VM its own LAN IP, exposing the QuickNotes service to every device on the same subnet — a security risk on shared or public networks (cafés, university Wi-Fi).
+
+**c) Provisioning — which tool and why?**
+
+I used the **Shell provisioner** (`config.vm.provision "shell"`). It ships built-in with Vagrant and requires zero extra tools on the host. For the single task of downloading and installing Go, a shell script is the most transparent and straightforward choice: any developer can read and verify it without knowing Ansible YAML or Chef DSL. Ansible is a much better fit for multi-role deployments (Lab 7 uses it for exactly that purpose), but for a one-step Go install it would be over-engineering.
+
+**d) Why pin Go to a specific point release (`1.24.5`) instead of `1.24`?**
+
+Go's official download server (`go.dev/dl/`) does not serve a floating tag like `go1.24.linux-amd64.tar.gz` — the URL requires a full three-part version such as `go1.24.5.linux-amd64.tar.gz`. More importantly, pinning ensures **reproducibility**: every student who clones the repo and runs `vagrant up` downloads the exact same binary regardless of when they run it. A floating minor version would silently pull in a different patch at different times, breaking the guarantee that the lab environment is identical across machines and over time. This is the same principle behind `go.sum` — the ecosystem pins hashes, not floating labels.
+
+---
+
+## Task 2 — Snapshots: Save, Break, Restore
+
+### Commands run
+
+**1. Take a clean snapshot after the app is running:**
+
+```bash
+vagrant snapshot save clean-go-install
+```
+
+```
+[OUTPUT]
+```
+
+**2. Break the VM — wipe the Go installation:**
+
+```bash
+vagrant ssh -c 'sudo rm -rf /usr/local/go && sudo rm -f /etc/profile.d/golang.sh'
+```
+
+**3. Verify it's broken:**
+
+```bash
+vagrant ssh -c 'go version'
+```
+
+```
+[OUTPUT — expected: "go: command not found" or similar error]
+```
+
+**4. Restore from the snapshot (timed):**
+
+```bash
+time vagrant snapshot restore clean-go-install
+```
+
+```
+[OUTPUT including real/user/sys time]
+```
+
+**5. Verify recovery:**
+
+```bash
+vagrant ssh -c 'go version'
+```
+
+```
+[OUTPUT — expected: go1.24.5 linux/amd64]
+```
+
+### Design Questions
+
+**e) Snapshots are not backups — why?**
+
+A snapshot lives on the same physical disk as the VM it protects. If the host's storage device fails (disk crash, RAID failure, accidental `rm -rf ~/VirtualBox\ VMs/`), the snapshot is destroyed along with the base disk — there is nothing to restore from. Snapshots also don't protect against logical failures that occurred *before* the snapshot was taken (silent data corruption, malware, a bad migration), and they provide no off-site copy. A true backup must be stored on a separate medium or location, and must be periodically tested by performing an actual restore.
+
+**f) Copy-on-write disk usage with 10 snapshots vs 1:**
+
+VirtualBox snapshots use a differencing (CoW) disk chain. When you take a snapshot, VirtualBox freezes the current `.vdi` and creates a new differencing disk for subsequent writes. With one snapshot, only blocks actually modified after the snapshot are stored in the delta file — initial cost is near zero. With 10 snapshots in a chain, every write creates a new delta entry in the most recent differencing disk, and reading any block may require walking back through the entire chain to find the newest version of it. Disk usage grows with the total amount of data changed across all layers combined; I/O overhead also grows linearly with chain depth.
+
+**g) When is snapshotting an antipattern?**
+
+Long snapshot chains are an antipattern in production because read performance degrades with each additional layer: VirtualBox must traverse every differencing disk in the chain to assemble the current block. For a VM that has accumulated dozens of snapshots over months, disk I/O can slow dramatically. Snapshotting is also an antipattern when it replaces *immutable infrastructure* thinking: if the VM is treated as a pet (never rebuilt from code, only snapshot-and-pray), the snapshot chain becomes the sole safety net — and it lives on the same host. The correct solution for production is cattle-style replacement from a versioned provisioning script (like the Vagrantfile itself) rather than preserving a fragile long-lived VM state.
+
+---
+
+## Bonus — VM vs Container Resource Baseline
+
+### Measurements
+
+**Vagrant VM (idle, after `vagrant up` with provisioning done):**
+
+```bash
+time vagrant halt && time vagrant up --no-provision   # cold boot only
+vagrant ssh -c 'free -h'
+vagrant ssh -c 'ps -A --no-headers | wc -l'
+du -sh ~/VirtualBox\ VMs/quicknotes-vm/
+```
+
+**Docker container (same QuickNotes):**
+
+```bash
+docker run -d --name qn-bench -p 28080:8080 \
+  -v "$PWD/app:/src" -w /src golang:1.24 \
+  sh -c 'go build -o /tmp/qn && /tmp/qn'
+
+docker stop qn-bench && time docker start qn-bench
+docker stats qn-bench --no-stream
+docker top qn-bench
+docker images golang:1.24 --format '{{.Size}}'
+```
+
+### Comparison Table
+
+| Dimension             | Vagrant VM | Docker container |
+|-----------------------|-----------:|-----------------:|
+| Cold start            |          ? |                ? |
+| Idle RAM              |          ? |                ? |
+| On-disk size          |          ? |                ? |
+| Process count (guest) |          ? |                ? |
+
+### Analysis
+
+[4-5 sentences to be filled in after running the measurements above. Expected observations: the VM cold start takes 30-60 seconds vs under 1 second for a stopped container; idle RAM will be ~200-400 MB for the VM (full kernel + init system) vs ~10-30 MB for the container; the Ubuntu box image is several GB vs ~1 GB for golang:1.24; process count in the VM will be 80-120 (full OS) vs 3-5 in the container. The data explains why containers became dominant for stateless microservices: faster startup, lower memory density, and a much smaller on-disk footprint enable far higher process density per host.]

--- a/submissions/lab5.md
+++ b/submissions/lab5.md
@@ -6,7 +6,7 @@
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box      = "ubuntu/jammy64"
+  config.vm.box      = "perk/ubuntu-2204-arm64"
   config.vm.hostname = "quicknotes-vm"
 
   config.vm.network "forwarded_port",
@@ -14,24 +14,30 @@ Vagrant.configure("2") do |config|
     host:    18080,
     host_ip: "127.0.0.1"
 
-  config.vm.synced_folder "./app", "/home/vagrant/app"
+  config.vm.synced_folder "./app", "/home/vagrant/app", type: "rsync",
+    rsync__exclude: [".git/", "data/", "quicknotes"]
 
-  config.vm.provider "virtualbox" do |vb|
-    vb.name   = "quicknotes-vm"
-    vb.cpus   = 2
-    vb.memory = 1024
+  config.vm.provider "qemu" do |qe|
+    qe.arch       = "aarch64"
+    qe.machine    = "virt,accel=hvf,highmem=off"
+    qe.cpu        = "host"
+    qe.net_device = "virtio-net-pci"
+    qe.memory     = "1024"
+    qe.smp        = "cpus=2"
   end
 
   config.vm.provision "shell", privileged: true, inline: <<-SHELL
     set -euo pipefail
     GO_VERSION="1.24.5"
-    GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
+    GO_TARBALL="go${GO_VERSION}.linux-arm64.tar.gz"
     GO_URL="https://go.dev/dl/${GO_TARBALL}"
 
     if /usr/local/go/bin/go version 2>/dev/null | grep -q "go${GO_VERSION}"; then
       echo "Go ${GO_VERSION} already installed, skipping."
       exit 0
     fi
+
+    echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
     echo ">>> Installing Go ${GO_VERSION}..."
     apt-get update -qq
@@ -54,18 +60,29 @@ end
 ### First 10 lines of `vagrant up`
 
 ```
-[OUTPUT]
+Bringing machine 'default' up with 'qemu' provider...
+==> default: Checking if box 'perk/ubuntu-2204-arm64' version '20250702' is up to date...
+==> default: Starting the instance...
+==> default: Waiting for machine to boot. This may take a few minutes...
+    default: SSH address: 127.0.0.1:50022
+    default: SSH username: vagrant
+    default: SSH auth method: private key
+    default: Warning: Connection reset. Retrying...
+    default: Warning: Remote connection disconnect. Retrying...
+==> default: Machine booted and ready!
+==> default: Setting hostname...
+==> default: Rsyncing folder: /Users/irina/Desktop/summer semester 2 year/DevOps-Intro/app/ => /home/vagrant/app
+==> default: Machine already provisioned. Run `vagrant provision` to re-run.
 ```
 
 ### `curl` from inside the VM
 
 ```bash
-vagrant ssh -c 'cd /home/vagrant/app && /usr/local/go/bin/go build -o /tmp/qn . && /tmp/qn &'
-vagrant ssh -c 'sleep 2 && curl -s http://localhost:8080/health'
+vagrant ssh -c 'cd /home/vagrant/app && nohup /tmp/qn > /tmp/qn.log 2>&1 & sleep 3 && curl -s http://localhost:8080/health'
 ```
 
 ```
-[OUTPUT]
+{"notes":4,"status":"ok"}
 ```
 
 ### `curl` from the host (via port forward)
@@ -75,14 +92,14 @@ curl -s http://localhost:18080/health
 ```
 
 ```
-[OUTPUT]
+{"notes":4,"status":"ok"}
 ```
 
 ### Design Questions
 
 **a) Synced folders — which type and why?**
 
-I used VirtualBox shared folders (the Vagrant default — no `type:` argument needed). This is the simplest option: the `ubuntu/jammy64` box ships with VirtualBox Guest Additions pre-installed, so no extra setup is required. The trade-off is I/O speed: VirtualBox shared folders are slower than NFS, especially for many small files or intensive file-watching workloads, because every filesystem call crosses the host–guest boundary through the VirtualBox kernel module. NFS would be faster but requires an NFS daemon on the host and `root`-level NFS exports, which adds friction for a course lab. `rsync` would be unidirectional (host → guest only) and would not reflect in-guest changes back to the host without `vagrant rsync-auto`.
+I used **rsync** (`type: "rsync"`). On Apple Silicon with the QEMU provider, VirtualBox shared folders are unavailable (no Guest Additions), and NFS requires root-level exports on the host. Rsync works over the existing SSH connection with no extra daemons. The trade-off is that it is **unidirectional** — changes sync from host to guest at `vagrant up` time (and on demand with `vagrant rsync`), but edits made inside the guest are not reflected back on the host automatically. For a read-only code mount (building Go inside the VM) this is a non-issue. NFS would give bidirectional, live sync with better performance for large trees, but the host setup overhead is not justified here.
 
 **b) NAT vs Bridged vs Host-only — which network mode?**
 
@@ -102,50 +119,57 @@ Go's official download server (`go.dev/dl/`) does not serve a floating tag like 
 
 ### Commands run
 
-**1. Take a clean snapshot after the app is running:**
+**1. Take a clean snapshot:**
 
 ```bash
-vagrant snapshot save clean-go-install
+vagrant halt
+qemu-img snapshot -c clean-go-install .vagrant/machines/default/qemu/vq_Ttb3NMInTpE/linked-box.img
+qemu-img snapshot -l .vagrant/machines/default/qemu/vq_Ttb3NMInTpE/linked-box.img
 ```
 
 ```
-[OUTPUT]
+==> default: Stopping the instance...
+Snapshot list:
+ID      TAG               VM_SIZE                DATE        VM_CLOCK     ICOUNT
+1       clean-go-install      0 B 2026-06-23 14:22:22  0000:00:00.000          0
 ```
 
 **2. Break the VM — wipe the Go installation:**
 
 ```bash
+vagrant up --no-provision
 vagrant ssh -c 'sudo rm -rf /usr/local/go && sudo rm -f /etc/profile.d/golang.sh'
 ```
 
 **3. Verify it's broken:**
 
 ```bash
-vagrant ssh -c 'go version'
+vagrant ssh -c '/usr/local/go/bin/go version'
 ```
 
 ```
-[OUTPUT — expected: "go: command not found" or similar error]
+bash: line 1: /usr/local/go/bin/go: No such file or directory
 ```
 
 **4. Restore from the snapshot (timed):**
 
 ```bash
-time vagrant snapshot restore clean-go-install
+vagrant halt && time qemu-img snapshot -a clean-go-install .vagrant/machines/default/qemu/vq_Ttb3NMInTpE/linked-box.img
 ```
 
 ```
-[OUTPUT including real/user/sys time]
+==> default: Stopping the instance...
+qemu-img snapshot -a clean-go-install   0.02s user 0.02s system 81% cpu 0.053 total
 ```
 
 **5. Verify recovery:**
 
 ```bash
-vagrant ssh -c 'go version'
+vagrant up --no-provision && vagrant ssh -c '/usr/local/go/bin/go version'
 ```
 
 ```
-[OUTPUT — expected: go1.24.5 linux/amd64]
+go version go1.24.5 linux/arm64
 ```
 
 ### Design Questions
@@ -162,43 +186,3 @@ VirtualBox snapshots use a differencing (CoW) disk chain. When you take a snapsh
 
 Long snapshot chains are an antipattern in production because read performance degrades with each additional layer: VirtualBox must traverse every differencing disk in the chain to assemble the current block. For a VM that has accumulated dozens of snapshots over months, disk I/O can slow dramatically. Snapshotting is also an antipattern when it replaces *immutable infrastructure* thinking: if the VM is treated as a pet (never rebuilt from code, only snapshot-and-pray), the snapshot chain becomes the sole safety net — and it lives on the same host. The correct solution for production is cattle-style replacement from a versioned provisioning script (like the Vagrantfile itself) rather than preserving a fragile long-lived VM state.
 
----
-
-## Bonus — VM vs Container Resource Baseline
-
-### Measurements
-
-**Vagrant VM (idle, after `vagrant up` with provisioning done):**
-
-```bash
-time vagrant halt && time vagrant up --no-provision   # cold boot only
-vagrant ssh -c 'free -h'
-vagrant ssh -c 'ps -A --no-headers | wc -l'
-du -sh ~/VirtualBox\ VMs/quicknotes-vm/
-```
-
-**Docker container (same QuickNotes):**
-
-```bash
-docker run -d --name qn-bench -p 28080:8080 \
-  -v "$PWD/app:/src" -w /src golang:1.24 \
-  sh -c 'go build -o /tmp/qn && /tmp/qn'
-
-docker stop qn-bench && time docker start qn-bench
-docker stats qn-bench --no-stream
-docker top qn-bench
-docker images golang:1.24 --format '{{.Size}}'
-```
-
-### Comparison Table
-
-| Dimension             | Vagrant VM | Docker container |
-|-----------------------|-----------:|-----------------:|
-| Cold start            |          ? |                ? |
-| Idle RAM              |          ? |                ? |
-| On-disk size          |          ? |                ? |
-| Process count (guest) |          ? |                ? |
-
-### Analysis
-
-[4-5 sentences to be filled in after running the measurements above. Expected observations: the VM cold start takes 30-60 seconds vs under 1 second for a stopped container; idle RAM will be ~200-400 MB for the VM (full kernel + init system) vs ~10-30 MB for the container; the Ubuntu box image is several GB vs ~1 GB for golang:1.24; process count in the VM will be 80-120 (full OS) vs 3-5 in the container. The data explains why containers became dominant for stateless microservices: faster startup, lower memory density, and a much smaller on-disk footprint enable far higher process density per host.]

--- a/submissions/lab7.md
+++ b/submissions/lab7.md
@@ -1,0 +1,294 @@
+# Lab 7 — Configuration Management: Deploy QuickNotes via Ansible
+
+## Ansible Layout
+
+```
+ansible/
+├── inventory.ini
+├── playbook.yaml
+├── files/
+│   ├── quicknotes          (static arm64 binary, CGO_ENABLED=0)
+│   └── seed.json
+└── templates/
+    └── quicknotes.service.j2
+```
+
+---
+
+## `playbook.yaml`
+
+```yaml
+---
+- name: Deploy QuickNotes to Vagrant VM
+  hosts: quicknotes_vm
+  become: true
+  gather_facts: false
+
+  vars:
+    quicknotes_user: quicknotes
+    quicknotes_data_dir: /var/lib/quicknotes
+    quicknotes_bin: /usr/local/bin/quicknotes
+    quicknotes_service: quicknotes
+    listen_addr: ":8080"
+    data_path: /var/lib/quicknotes/notes.json
+    seed_path: /var/lib/quicknotes/seed.json
+
+  handlers:
+    - name: restart quicknotes
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service }}"
+        state: restarted
+        daemon_reload: true
+
+  tasks:
+    - name: Create quicknotes system user
+      ansible.builtin.user:
+        name: "{{ quicknotes_user }}"
+        system: true
+        shell: /usr/sbin/nologin
+        create_home: false
+
+    - name: Ensure data directory exists
+      ansible.builtin.file:
+        path: "{{ quicknotes_data_dir }}"
+        state: directory
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0750"
+
+    - name: Copy QuickNotes binary
+      ansible.builtin.copy:
+        src: files/quicknotes
+        dest: "{{ quicknotes_bin }}"
+        owner: root
+        group: root
+        mode: "0755"
+      notify: restart quicknotes
+
+    - name: Copy seed.json to data directory
+      ansible.builtin.copy:
+        src: files/seed.json
+        dest: "{{ quicknotes_data_dir }}/seed.json"
+        owner: "{{ quicknotes_user }}"
+        group: "{{ quicknotes_user }}"
+        mode: "0640"
+
+    - name: Render systemd unit from template
+      ansible.builtin.template:
+        src: templates/quicknotes.service.j2
+        dest: /etc/systemd/system/quicknotes.service
+        owner: root
+        group: root
+        mode: "0644"
+      notify: restart quicknotes
+
+    - name: Enable and start quicknotes service
+      ansible.builtin.systemd:
+        name: "{{ quicknotes_service }}"
+        enabled: true
+        state: started
+        daemon_reload: true
+```
+
+---
+
+## `inventory.ini`
+
+```ini
+[quicknotes_vm]
+quicknotes ansible_host=127.0.0.1 ansible_port=50022 ansible_user=vagrant \
+  ansible_ssh_private_key_file=.vagrant/machines/default/qemu/private_key \
+  ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa'
+```
+
+Port and key path taken directly from `vagrant ssh-config`.
+
+---
+
+## `templates/quicknotes.service.j2`
+
+```ini
+[Unit]
+Description=QuickNotes HTTP service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User={{ quicknotes_user }}
+WorkingDirectory={{ quicknotes_data_dir }}
+ExecStart={{ quicknotes_bin }}
+Environment=ADDR={{ listen_addr }}
+Environment=DATA_PATH={{ data_path }}
+Environment=SEED_PATH={{ seed_path }}
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+```
+
+---
+
+## Task 1 — First Run PLAY RECAP
+
+```
+PLAY [Deploy QuickNotes to Vagrant VM] *****************************************
+
+TASK [Create quicknotes system user] *******************************************
+changed: [quicknotes]
+
+TASK [Ensure data directory exists] ********************************************
+changed: [quicknotes]
+
+TASK [Copy QuickNotes binary] **************************************************
+changed: [quicknotes]
+
+TASK [Copy seed.json to data directory] ****************************************
+changed: [quicknotes]
+
+TASK [Render systemd unit from template] ***************************************
+changed: [quicknotes]
+
+TASK [Enable and start quicknotes service] *************************************
+changed: [quicknotes]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes]
+
+PLAY RECAP *********************************************************************
+quicknotes                 : ok=7    changed=7    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+## `curl` proof
+
+```
+$ curl -s http://localhost:18080/health
+{"notes":4,"status":"ok"}
+
+$ curl -s http://localhost:18080/notes
+[{"id":1,"title":"Welcome to QuickNotes","body":"This is the project you'll containerize, deploy, monitor, and harden across all 10 labs.","created_at":"2026-01-15T10:00:00Z"},{"id":2,"title":"Read app/main.go first","body":"Start by understanding the entry point — env vars, signal handling, graceful shutdown.","created_at":"2026-01-15T10:05:00Z"},{"id":3,"title":"DevOps mantra","body":"If it hurts, do it more often.","created_at":"2026-01-15T10:10:00Z"},{"id":4,"title":"Endpoint cheat-sheet","body":"GET /notes  GET /notes/{id}  POST /notes  DELETE /notes/{id}  GET /health  GET /metrics","created_at":"2026-01-15T10:15:00Z"}]
+```
+
+---
+
+## Task 1 — Design Questions
+
+### a) `command:` vs dedicated modules — idempotency
+
+`command:` and `shell:` simply execute a shell string. They have no awareness of desired state: they run every time unconditionally, so Ansible always reports `changed=1` even when nothing actually needs doing. Dedicated modules like `apt`, `file`, `copy`, and `systemd` know the *desired* state and first check if the system already matches it. If it does, they do nothing and report `ok`. That check-then-act pattern is the definition of idempotency. It matters because a non-idempotent playbook cannot be run safely a second time — you lose the ability to detect drift and to use `--check` for safe pre-flight verification.
+
+### b) `notify:` and handlers — when a handler fires and when it doesn't
+
+A handler fires **once at the end of the play** (in the `RUNNING HANDLERS` section), and only if the task that `notify:`-ed it actually reported `changed`. If the task reports `ok` (nothing changed), the handler is never triggered. If multiple tasks notify the same handler, the handler still runs only once. This is the right default because restarting a service is disruptive — it should happen only when a real change was made (new binary or new config), not on every playbook run. Running handlers only when needed keeps the deploy safe and predictable.
+
+### c) Variable hierarchy — top 3 places for this lab
+
+1. **`vars:` block in the play** — used here. Highest-precedence "source of truth" when you want all variables visible in one place alongside the tasks. Good for lab-sized playbooks.
+2. **`group_vars/quicknotes_vm.yaml`** — the right place for per-environment values (staging vs production addr, paths). Separates data from logic and scales when you add more hosts.
+3. **`defaults/main.yaml` (role defaults)** — if the playbook were refactored into a role, defaults provide lowest-precedence fallbacks that are easy to override from any other level without touching the role itself.
+
+### d) `gather_facts: true` — is it needed?
+
+Not needed for this playbook. None of the tasks reference `ansible_*` facts (OS family, architecture, IP, etc.) — all values come from explicit variables. Turning it off with `gather_facts: false` saves one SSH round-trip that collects ~200 facts per host. On a single-VM lab run the saving is ~1–2 seconds; across 100 hosts it becomes significant enough to matter in CI.
+
+---
+
+## Task 2 — Second Run (Idempotency)
+
+```
+PLAY RECAP *********************************************************************
+quicknotes                 : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+`changed=0` — all tasks found the host already in the desired state.
+
+---
+
+## Task 2 — Variable Tweak: `listen_addr=:9090`
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml -e "listen_addr=:9090"
+```
+
+```
+TASK [Create quicknotes system user] *******************************************
+ok: [quicknotes]
+
+TASK [Ensure data directory exists] ********************************************
+ok: [quicknotes]
+
+TASK [Copy QuickNotes binary] **************************************************
+ok: [quicknotes]
+
+TASK [Copy seed.json to data directory] ****************************************
+ok: [quicknotes]
+
+TASK [Render systemd unit from template] ***************************************
+changed: [quicknotes]
+
+TASK [Enable and start quicknotes service] *************************************
+ok: [quicknotes]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes]
+
+PLAY RECAP *********************************************************************
+quicknotes                 : ok=7    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+Only the `template` task changed (unit file rewritten) and the `restart quicknotes` handler fired. All other tasks: `ok`.
+
+---
+
+## Task 2 — `--check --diff` Preview (`listen_addr=:7070`)
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yaml --check --diff -e "listen_addr=:7070"
+```
+
+```
+TASK [Render systemd unit from template] ***************************************
+--- before: /etc/systemd/system/quicknotes.service
++++ after: /Users/irina/.ansible/tmp/.../quicknotes.service.j2
+@@ -7,7 +7,7 @@
+ User=quicknotes
+ WorkingDirectory=/var/lib/quicknotes
+ ExecStart=/usr/local/bin/quicknotes
+-Environment=ADDR=:8080
++Environment=ADDR=:7070
+ Environment=DATA_PATH=/var/lib/quicknotes/notes.json
+ Environment=SEED_PATH=/var/lib/quicknotes/seed.json
+ Restart=on-failure
+
+changed: [quicknotes]
+
+RUNNING HANDLER [restart quicknotes] *******************************************
+changed: [quicknotes]
+
+PLAY RECAP *********************************************************************
+quicknotes                 : ok=7    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
+```
+
+No actual changes were applied (dry-run mode).
+
+---
+
+## Task 2 — Design Questions
+
+### e) Why does the second run report `changed=0`?
+
+The `file` module computes the desired state (path, owner, group, mode) and compares it to the actual inode metadata on disk — if they match, it does nothing. The `template` module renders the Jinja2 template in memory and computes a checksum of the result, then compares it to the checksum of the existing file on the remote host. The `copy` module does the same with a local file checksum vs remote file checksum. The `user` module reads `/etc/passwd`. Because nothing changed between run 1 and run 2, every check passes and nothing is written — `changed=0`.
+
+### f) `shell: 'echo "ADDR=..." > /etc/systemd/system/quicknotes.service'` instead of `template:`
+
+Multiple failure modes:
+1. **Not idempotent**: `shell:` runs unconditionally, so every run overwrites the file and reports `changed=1`, triggering the `restart quicknotes` handler every time — unnecessary service disruptions.
+2. **Truncation / quoting**: a complex unit file written via `echo` needs careful quoting (single vs double quotes, `$` signs); a missed escape silently corrupts the file.
+3. **No diff**: `--check --diff` can't show what will change because `shell:` doesn't know the current content or the desired content.
+4. **No checksum check**: the module won't detect if the file was manually edited between runs (drift is invisible).
+5. **Permissions**: `echo ... >` inherits the shell's umask — you'd need an extra `chmod` task to set `0644`, adding another non-idempotent step.
+
+### g) Bug caught by `--check --diff` that plain `--check` misses
+
+`--check` tells you *which* tasks would change, but not *what* would change. With `--diff` you see the exact before/after diff of each file. A common production bug: a variable substitution renders an unexpected value (e.g., `{{ listen_addr }}` evaluates to an empty string because the variable was accidentally unset), making the unit file syntactically invalid. `--check` alone says "template: changed" — looks fine. `--check --diff` shows `-Environment=ADDR=:8080` / `+Environment=ADDR=` — the empty value is immediately visible, and you catch the misconfiguration before it kills the running service.


### PR DESCRIPTION
## Summary

- Idempotent Ansible playbook (`ansible/playbook.yaml`) deploys QuickNotes to the Lab 5 Vagrant VM via `become: true`
- Creates system user `quicknotes`, data directory `/var/lib/quicknotes`, copies static binary and seed.json, renders systemd unit from Jinja2 template, enables and starts the service
- Handler `restart quicknotes` fires only when the binary or unit file changes
- `gather_facts: false` — no facts needed since all values come from explicit variables

## Test plan

- [x] First run: `changed=7`, service `active (running)`, `curl :18080/health` → `{"notes":4,"status":"ok"}`
- [x] Second run: `changed=0` (full idempotency confirmed)
- [x] Variable tweak (`listen_addr=:9090`): only `template` task + handler changed (`changed=2`)
- [x] `--check --diff` with `listen_addr=:7070`: exact diff shown, no changes applied
- [x] All 7 design questions answered in `submissions/lab7.md`