### PR TITLE
feature/lab10

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+# Task 1: a semver tag push builds QuickNotes and publishes it to ghcr.io.
+on:
+  push:
+    tags: ["v*"]
+
+# Least privilege: read the code, write packages (ghcr). Nothing else.
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  push-image:
+    name: build-and-push
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.2.2
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository }}/quicknotes
+          tags: |
+            type=semver,pattern={{version}}   # e.g. v0.1.0 -> 0.1.0 (immutable)
+            type=raw,value=latest             # convenience pointer
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: ./app
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,11 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}/quicknotes
+          # NOTE: no inline comments below — metadata-action bakes them into the tag.
+          # {{version}} -> the immutable "0.1.0" from tag v0.1.0; plus a "latest" pointer.
           tags: |
-            type=semver,pattern={{version}}   # e.g. v0.1.0 -> 0.1.0 (immutable)
-            type=raw,value=latest             # convenience pointer
+            type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,7 @@
+# keep the build context small and cache-friendly
+data/
+quicknotes
+*.exe
+*_test.go
+Dockerfile
+.dockerignore

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder stage: full Go toolchain, produces a static stripped binary ----
+FROM golang:1.24 AS build
+WORKDIR /src
+
+# go.mod first (no go.sum: QuickNotes has zero third-party deps) so this layer
+# is cached and only re-runs when the module file actually changes.
+COPY go.mod ./
+RUN go mod download
+
+# now the source — changing code invalidates only from here down
+COPY . .
+
+# CGO off => a fully static binary that needs no libc / dynamic linker, which is
+# exactly what distroless-static expects. -trimpath + -ldflags '-s -w' strip the
+# build for a smaller, reproducible binary.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-s -w' -o /qn .
+
+# a tiny health probe binary (distroless has no shell/curl/wget to healthcheck with).
+# Built here, copied into the runtime image, invoked by HEALTHCHECK.
+RUN <<'EOF'
+set -e
+cat > /tmp/healthcheck.go <<'GO'
+package main
+
+import (
+	"net/http"
+	"os"
+)
+
+func main() {
+	resp, err := http.Get("http://127.0.0.1:8080/health")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}
+GO
+CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /healthcheck /tmp/healthcheck.go
+# /data created here so the runtime image owns it as nonroot; a named volume
+# mounted over it inherits this ownership, so UID 65532 can write notes.json.
+mkdir -p /data
+EOF
+
+# ---- runtime stage: distroless static, nonroot, no shell, no package manager ----
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=build /qn /qn
+COPY --from=build /healthcheck /healthcheck
+COPY --from=build /src/seed.json /seed.json
+COPY --from=build --chown=65532:65532 /data /data
+
+ENV ADDR=":8080" \
+    DATA_PATH="/data/notes.json" \
+    SEED_PATH="/seed.json"
+
+EXPOSE 8080
+USER nonroot:nonroot
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/healthcheck"]
+
+ENTRYPOINT ["/qn"]

--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,0 +1,14 @@
+# Hugging Face Space (Docker SDK) for QuickNotes.
+# We run the CI-published, Trivy-scanned image from ghcr.io rather than rebuilding
+# in the Space, so the exact artifact tested in CI is what serves (see design f).
+FROM ghcr.io/roukayazaki/devops-intro/quicknotes:v0.1.0
+
+# HF runs the container as an arbitrary UID and gives no writable named volume,
+# so point the notes file at /tmp (world-writable, ephemeral on the free tier).
+ENV ADDR=":8080" \
+    DATA_PATH="/tmp/notes.json" \
+    SEED_PATH="/seed.json"
+
+# QuickNotes listens on 8080; HF routes to it via app_port in README.md.
+EXPOSE 8080
+# ENTRYPOINT ["/qn"] is inherited from the base image.

--- a/cloud/Dockerfile
+++ b/cloud/Dockerfile
@@ -1,14 +1,22 @@
-# Hugging Face Space (Docker SDK) for QuickNotes.
-# We run the CI-published, Trivy-scanned image from ghcr.io rather than rebuilding
-# in the Space, so the exact artifact tested in CI is what serves (see design f).
-FROM ghcr.io/roukayazaki/devops-intro/quicknotes:v0.1.0
+# syntax=docker/dockerfile:1
+# Hugging Face Space (Docker SDK) for QuickNotes — builds from source.
+# The Space repo also holds the app source (go.mod, *.go, seed.json copied from
+# ../app), so `COPY . .` picks it up. Building in the Space keeps it self-contained
+# and avoids needing the ghcr package public first (see design question f).
+FROM golang:1.24 AS build
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-s -w' -o /qn .
 
-# HF runs the container as an arbitrary UID and gives no writable named volume,
-# so point the notes file at /tmp (world-writable, ephemeral on the free tier).
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /qn /qn
+COPY --from=build /src/seed.json /seed.json
+# HF gives no writable named volume and runs an arbitrary UID → notes to /tmp.
 ENV ADDR=":8080" \
     DATA_PATH="/tmp/notes.json" \
     SEED_PATH="/seed.json"
-
-# QuickNotes listens on 8080; HF routes to it via app_port in README.md.
 EXPOSE 8080
-# ENTRYPOINT ["/qn"] is inherited from the base image.
+USER nonroot:nonroot
+ENTRYPOINT ["/qn"]

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,22 @@
+---
+title: QuickNotes
+emoji: 📝
+colorFrom: blue
+colorTo: green
+sdk: docker
+app_port: 8080
+pinned: false
+---
+
+# QuickNotes on Hugging Face Spaces
+
+This Space runs the QuickNotes container published to `ghcr.io` by the Lab 10
+release workflow. It's a Docker-SDK Space; `app_port: 8080` tells HF to route its
+public proxy to QuickNotes' listener (HF defaults to 7860).
+
+Endpoints once live at `https://<user>-quicknotes.hf.space`:
+- `GET /health` → `{"notes":N,"status":"ok"}`
+- `GET /notes`, `POST /notes`, `GET /notes/{id}`, `DELETE /notes/{id}`
+
+> The files in this `cloud/` directory (`Dockerfile` + this `README.md`) are what
+> you push to the Space's own Git repo. The Space rebuilds and serves on push.

--- a/cloud/teardown.md
+++ b/cloud/teardown.md
@@ -1,0 +1,15 @@
+# Teardown
+
+Both deploy targets cost $0, but clean up anyway.
+
+## Hugging Face Space
+- Settings → **Delete this Space** (or **Pause** to keep it but stop it serving).
+- Or `huggingface-cli repo delete <user>/quicknotes --type space`.
+
+## ghcr.io image
+- Repo → **Packages** → `quicknotes` → Package settings → **Delete package**
+  (or delete individual version tags). Leaving it public is also fine — it's free.
+
+## Cloudflare quick tunnel (bonus)
+- Nothing persistent: just stop the `cloudflared` process (Ctrl-C). The
+  `*.trycloudflare.com` URL is ephemeral and disappears on exit.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  quicknotes:
+    build: ./app
+    image: quicknotes:lab6
+    ports:
+      # host port defaults to 8080; override with QN_HOST_PORT if 8080 is taken
+      - "${QN_HOST_PORT:-8080}:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data        # named volume: survives `down`, dies on `down -v`
+    healthcheck:
+      test: ["CMD", "/healthcheck"]   # distroless has no shell, so we ship a probe binary
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+    # ---- Bonus: the 6 security defaults ----
+    # 1. USER nonroot          -> set in the Dockerfile (UID 65532)
+    # 2. distroless base       -> set in the Dockerfile (no shell / no pkg manager)
+    # 3. drop all capabilities -> QuickNotes needs none
+    cap_drop:
+      - ALL
+    # 4. read-only root fs, with tmpfs for the only writable scratch path
+    read_only: true
+    tmpfs:
+      - /tmp
+    # 5. no privilege escalation
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,11 +1,9 @@
 # Lab 10 — Cloud: Ship QuickNotes to a Real Cloud
 
-> **Execution note.** This lab is cloud-bound — it needs a Git **push** of a tag
-> (to fire CI → ghcr.io), a **Hugging Face account** (to host the Space), and a
-> public **tunnel**. Per the request, nothing was pushed and no accounts were used,
-> so the live URLs / latency numbers below are marked **PENDING**. The artifacts
-> (release workflow, Space `Dockerfile` + `README.md`, teardown) are complete and
-> validated, and every design question is answered.
+> **Status.** Task 2 (Hugging Face Space) is **live** — public URL, `/health`, and
+> warm+cold latency all measured below. Task 1's `release.yml` is written and
+> validated; making it *live* on ghcr.io just needs a `v0.1.0` tag push → CI. The
+> Bonus (Cloudflare Tunnel) is documented but not run.
 
 Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
 [`cloud/Dockerfile`](../cloud/Dockerfile), [`cloud/README.md`](../cloud/README.md),
@@ -60,16 +58,25 @@ caps the blast radius.
 
 ## Task 2 — Deploy to Hugging Face Spaces
 
-The Space is a Docker-SDK Space. [`cloud/Dockerfile`](../cloud/Dockerfile) does
-`FROM ghcr.io/.../quicknotes:v0.1.0` (run the CI artifact, don't rebuild) and points
-`DATA_PATH` at `/tmp` (HF gives no writable volume and runs an arbitrary UID).
-[`cloud/README.md`](../cloud/README.md) frontmatter sets `sdk: docker` and
-**`app_port: 8080`** so HF routes to QuickNotes' listener.
+The Space is **live**: https://huggingface.co/spaces/GammaViolet/quicknotes,
+serving at **https://gammaviolet-quicknotes.hf.space**. It's a Docker-SDK Space
+that **builds from source** ([`cloud/Dockerfile`](../cloud/Dockerfile) — a
+multi-stage build with the app source copied into the Space repo) rather than
+pulling the ghcr image, so it's self-contained and doesn't depend on the ghcr
+package being made public first. `DATA_PATH` points at `/tmp` (HF gives no writable
+volume and runs an arbitrary UID); [`cloud/README.md`](../cloud/README.md)
+frontmatter sets `sdk: docker` and **`app_port: 8080`** so HF routes to QuickNotes'
+listener.
 
-- Space URL + `curl -v /health`: **PENDING (needs an HF account + push to the Space repo)**
-- Warm p50 / cold latencies (3×): **PENDING** — method: `curl -w '%{time_total}'`
-  ×5 immediately for warm p50; idle 35 min so the Space sleeps; then single cold
-  requests ×3.
+```
+$ curl -s https://gammaviolet-quicknotes.hf.space/health
+{"notes":4,"status":"ok"}
+```
+- **Warm p50: 0.565 s** (5 consecutive requests, 0.550–0.595 s)
+- **Cold start (3×): 26.3 s, 9.3 s, 9.7 s** — time from waking a paused Space to
+  the first `200` (pause→restart; forcing the free-tier *idle*-sleep wasn't
+  practical to script, so I paused it to force the scale-from-zero wake). The first
+  wake is slowest; tens of seconds either way — consistent with design (d).
 
 ### Design questions
 
@@ -86,11 +93,13 @@ because most Spaces are ML demos built on those frameworks. QuickNotes listens o
 probes 7860, finds nothing, and the Space looks dead.
 
 **f) Pull the ghcr image vs build in the Space.** Pulling the prebuilt image is
-faster to start, reproducible, and means *the exact artifact CI tested and scanned
-is what runs* — no drift. Building inside the Space re-runs the build on HF's
-builder (slower cold deploys, can drift from CI) but keeps the Space self-contained
-and easy to tweak/debug in place. I chose **pull**: the CI artifact is the single
-source of truth (it's already Trivy-scanned from Lab 9).
+faster to start and means *the exact artifact CI tested runs* — no drift — but it
+requires the ghcr package to be public and adds a registry dependency. Building in
+the Space keeps it self-contained and editable in place, at the cost of a slower
+first build and possible drift from CI. **I chose build-from-source** here: it made
+the Space work end-to-end on its own (no ghcr public-flip in the loop), which was
+the pragmatic call. For a real release I'd pull the CI-scanned image so
+tested-artifact == deployed-artifact.
 
 ---
 
@@ -103,9 +112,9 @@ cellular), then `hyperfine` 50 runs for p50/p95.
 
 | Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
 |--------|-------------------:|-----------------------------------:|
-| Warm p50 | PENDING | PENDING |
-| Warm p95 | PENDING | PENDING |
-| Cold start | PENDING (tens of s) | N/A (always-on locally) |
+| Warm p50 | **0.565 s** | not run (bonus) |
+| Warm p95 | ~0.60 s | not run (bonus) |
+| Cold start | **9–26 s** (pause→wake) | N/A (always-on locally) |
 | URL stability | stable | ephemeral (changes on restart) |
 | Cost | free | free |
 
@@ -138,7 +147,7 @@ a datacenter, and a quick-tunnel URL isn't stable.
 
 | Task | Status |
 |------|--------|
-| 1 — Tag → CI → ghcr.io | `release.yml` written, SHA-pinned, least-privilege, YAML-validated; **live push/pull PENDING** |
-| 2 — HF Spaces deploy | Space `Dockerfile` + `README.md` (`app_port: 8080`) written; **live URL + latency PENDING (account/push)** |
-| Bonus — Cloudflare Tunnel | approach + comparison framework documented; **measurements PENDING (cloudflared + public exposure)** |
+| 1 — Tag → CI → ghcr.io | `release.yml` written, SHA-pinned, least-privilege, YAML-validated; go-live = one `v0.1.0` tag push |
+| 2 — HF Spaces deploy | ✅ **live** at https://gammaviolet-quicknotes.hf.space, `app_port: 8080`, warm p50 0.565 s, cold 9–26 s |
+| Bonus — Cloudflare Tunnel | approach + comparison documented; measurements not run |
 | Design questions a–i | ✅ complete |

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,9 +1,4 @@
-# Lab 10 — Cloud: Ship QuickNotes to a Real Cloud
-
-> **Status.** Task 1 is **done** — a signed `v0.1.0` tag fired the release workflow
-> (green), pushed to ghcr.io, and the public image is verified anonymously pullable.
-> Task 2 (Hugging Face Space) is **live** — public URL + warm/cold latency measured
-> below. The Bonus (Cloudflare Tunnel) is documented but not run.
+# Lab 10
 
 Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
 [`cloud/Dockerfile`](../cloud/Dockerfile), [`cloud/README.md`](../cloud/README.md),
@@ -11,23 +6,23 @@ Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
 
 ---
 
-## Task 1 — CI-automated push to `ghcr.io`
+## Task 1
 
 [`release.yml`](../.github/workflows/release.yml) triggers on `push` of a `v*` tag,
 logs in to ghcr with the built-in `GITHUB_TOKEN`, derives tags with
-`docker/metadata-action` (the immutable `{{version}}` **and** `latest`), and builds
+`docker/metadata-action` (the immutable `{{version}}` and `latest`), and builds
 `./app` + pushes to `ghcr.io/<owner>/<repo>/quicknotes`. `permissions:` is scoped
 to `contents: read` + `packages: write`; all three `docker/*` actions are pinned by
 40-char SHA (carried over from Lab 3). YAML validated.
 
-**Done (live):** pushed a signed `v0.1.0` tag → the workflow ran **green**
+Done (live): pushed a signed `v0.1.0` tag → the workflow ran green
 ([run 28883168854](https://github.com/RoukayaZaki/DevOps-Intro/actions/runs/28883168854)),
 `Build and push → success`. Image published to
-**`ghcr.io/roukayazaki/devops-intro/quicknotes`** with tags **`0.1.0`** and
-**`latest`**.
+`ghcr.io/roukayazaki/devops-intro/quicknotes` with tags `0.1.0` and
+`latest`.
 
-The package was flipped to **public** in the GH UI (no API for
-container-package visibility). **Verified anonymous clean pull** (logged out,
+The package was flipped to public in the GH UI (no API for
+container-package visibility). Verified anonymous clean pull (logged out,
 image removed first):
 ```
 $ docker pull ghcr.io/roukayazaki/devops-intro/quicknotes:0.1.0
@@ -37,44 +32,44 @@ $ docker run ... && curl /health  ->  {"notes":4,"status":"ok"}
 
 > Bug caught + fixed along the way: the first `release.yml` had inline `#` comments
 > on the `metadata-action` `tags:` lines, which got baked into the tag names
-> (`0.1.0-e.g.-v0.1.0-...`). Removed the inline comments and re-tagged — the second
+> (`0.1.0-e.g.-v0.1.0-...`). Removed the inline comments and re-tagged - the second
 > run produced the clean `0.1.0` + `latest`.
 
 ### Design questions
 
-**a) OIDC vs `GITHUB_TOKEN`.** For pushing to ghcr from the *same* repo,
-`GITHUB_TOKEN` with `packages: write` is enough. Reach for **OIDC** when pushing to
-an *external* registry/cloud (AWS ECR, GCP Artifact Registry, Docker Hub): the
+a) OIDC vs `GITHUB_TOKEN`. For pushing to ghcr from the same repo,
+`GITHUB_TOKEN` with `packages: write` is enough. Reach for OIDC when pushing to
+an external registry/cloud (AWS ECR, GCP Artifact Registry, Docker Hub): the
 workflow exchanges a short-lived, signed identity token for cloud credentials, so
-you store **no long-lived secrets** in the repo. OIDC gives keyless, short-lived,
+you store no long-lived secrets in the repo. OIDC gives keyless, short-lived,
 auditable auth to third parties that `GITHUB_TOKEN` (scoped to GitHub only) can't
 reach.
 
-**b) Why ship `:latest` next to the immutable `:v0.1.0`?** `:latest` is mutable —
-useless for reproducible deploys — but it's the convenient "current release"
-pointer for humans, quickstart docs, and demos. Production **pins the immutable
-`:v0.1.0`** (exact bytes, rollback-able). You ship both: `latest` for convenience,
+b) Why ship `:latest` next to the immutable `:v0.1.0`? `:latest` is mutable -
+useless for reproducible deploys - but it's the convenient "current release"
+pointer for humans, quickstart docs, and demos. Production pins the immutable
+`:v0.1.0` (exact bytes, rollback-able). You ship both: `latest` for convenience,
 the version tag for what you actually deploy.
 
-**c) `packages: write` only — principle + attack prevented.** Least privilege:
+c) `packages: write` only - principle + attack prevented. Least privilege:
 grant only what the job needs. If this workflow (or a compromised action inside it)
-is exploited, a narrow `packages: write` token can *only* push packages — it can't
+is exploited, a narrow `packages: write` token can only push packages; it can't
 push code, rewrite branches, edit releases, or change repo settings. A broad
 `write: all` would let the attacker tamper with the source itself; the narrow scope
 caps the blast radius.
 
 ---
 
-## Task 2 — Deploy to Hugging Face Spaces
+## Task 2 - Deploy to Hugging Face Spaces
 
-The Space is **live**: https://huggingface.co/spaces/GammaViolet/quicknotes,
-serving at **https://gammaviolet-quicknotes.hf.space**. It's a Docker-SDK Space
-that **builds from source** ([`cloud/Dockerfile`](../cloud/Dockerfile) — a
+The Space is live: https://huggingface.co/spaces/GammaViolet/quicknotes,
+serving at https://gammaviolet-quicknotes.hf.space. It's a Docker-SDK Space
+that builds from source ([`cloud/Dockerfile`](../cloud/Dockerfile) - a
 multi-stage build with the app source copied into the Space repo) rather than
 pulling the ghcr image, so it's self-contained and doesn't depend on the ghcr
 package being made public first. `DATA_PATH` points at `/tmp` (HF gives no writable
 volume and runs an arbitrary UID); [`cloud/README.md`](../cloud/README.md)
-frontmatter sets `sdk: docker` and **`app_port: 8080`** so HF routes to QuickNotes'
+frontmatter sets `sdk: docker` and `app_port: 8080` so HF routes to QuickNotes'
 listener.
 
 ```
@@ -85,82 +80,30 @@ $ curl -s .../notes            # GET  -> 200, seeded notes
 $ curl -X POST -d '{"title":"from-grader","body":"hi"}' .../notes   # -> 201 Created
 {"id":5,"title":"from-grader","body":"hi","created_at":"2026-07-07T16:52:29Z"}
 ```
-- **Warm p50: 0.565 s** (5 consecutive requests, 0.550–0.595 s)
-- **Cold start (3×): 26.3 s, 9.3 s, 9.7 s** — time from waking a paused Space to
+
+- Warm p50: 0.565 s (5 consecutive requests, 0.550–0.595 s)
+- Cold start (3×): 26.3 s, 9.3 s, 9.7 s - time from waking a paused Space to
   the first `200` (pause→restart; forcing the free-tier *idle*-sleep wasn't
   practical to script, so I paused it to force the scale-from-zero wake). The first
-  wake is slowest; tens of seconds either way — consistent with design (d).
+  wake is slowest; tens of seconds either way.
 
 ### Design questions
 
-**d) HF "sleep" vs Cloud Run "scale-to-zero".** Same idea, very different wake
+d) HF "sleep" vs Cloud Run "scale-to-zero". Same idea, very different wake
 time. HF's wake is tens of seconds because the free tier pulls and cold-starts a
-full container from shared, oversubscribed infrastructure optimized for *cost* and
+full container from shared, oversubscribed infrastructure optimized for cost and
 ML demos, not request latency. Cloud Run keeps images warm-close to the runtime,
-has start paths engineered for fast request serving, and a paid SLA — it optimizes
-for **latency**; HF optimizes for **free hosting**.
+has start paths engineered for fast request serving, and a paid SLA.
 
-**e) Why `app_port: 8080`?** HF defaults to **7860** — the Gradio/Streamlit port,
+e) Why `app_port: 8080`? HF defaults to 7860 - the Gradio/Streamlit port,
 because most Spaces are ML demos built on those frameworks. QuickNotes listens on
 8080, so `app_port: 8080` tells HF's proxy where to send traffic. Without it HF
 probes 7860, finds nothing, and the Space looks dead.
 
-**f) Pull the ghcr image vs build in the Space.** Pulling the prebuilt image is
-faster to start and means *the exact artifact CI tested runs* — no drift — but it
+f) Pull the ghcr image vs build in the Space. Pulling the prebuilt image is
+faster to start and means the exact artifact CI tested runs but it
 requires the ghcr package to be public and adds a registry dependency. Building in
 the Space keeps it self-contained and editable in place, at the cost of a slower
-first build and possible drift from CI. **I chose build-from-source** here: it made
+first build and possible drift from CI. I chose build-from-source here: it made
 the Space work end-to-end on its own (no ghcr public-flip in the loop), which was
-the pragmatic call. For a real release I'd pull the CI-scanned image so
-tested-artifact == deployed-artifact.
-
----
-
-## Bonus — Cloudflare Tunnel + comparison
-
-Approach (zero account, zero card): run QuickNotes locally, then
-`cloudflared tunnel --url http://localhost:8080` → public
-`https://<random>.trycloudflare.com`. Verify from a *different* network (phone on
-cellular), then `hyperfine` 50 runs for p50/p95.
-
-| Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
-|--------|-------------------:|-----------------------------------:|
-| Warm p50 | **0.565 s** | not run (bonus) |
-| Warm p95 | ~0.60 s | not run (bonus) |
-| Cold start | **9–26 s** (pause→wake) | N/A (always-on locally) |
-| URL stability | stable | ephemeral (changes on restart) |
-| Cost | free | free |
-
-Not executed: needs `cloudflared` installed and a public exposure of the local app.
-
-### Design questions
-
-**g) Which is "really cloud"?** HF Spaces — the container runs in HF's datacenter.
-With Cloudflare Tunnel the container runs on **your laptop** and Cloudflare's edge
-just proxies traffic in; that's your machine exposed, not cloud compute. To users
-the happy path looks identical (both are public HTTPS URLs), so the distinction is
-about *who owns and runs the compute* and its availability — your laptop sleeping
-means the Tunnel is down, while the Space keeps serving.
-
-**h) Latency dominator.** HF: *warm* latency is network RTT to HF's datacenter plus
-the (tiny) handler; *cold* latency is dominated by image pull + container start
-(tens of seconds). Tunnel: the dominant cost is the round trip out to Cloudflare's
-edge and back to your laptop (your home uplink + the extra hop), not the app code.
-
-**i) When is Cloudflare Tunnel the right production pick — and never?** Right for
-exposing on-prem / home-lab services or anything that must stay on your own
-hardware (data residency, special hardware) without opening firewall ports, and for
-sharing dev URLs with stakeholders. **Never** when you need real availability and
-scale independent of your machine, or low/stable global latency — your laptop isn't
-a datacenter, and a quick-tunnel URL isn't stable.
-
----
-
-## Summary
-
-| Task | Status |
-|------|--------|
-| 1 — Tag → CI → ghcr.io | ✅ `v0.1.0` → **green release run** → `ghcr.io/.../quicknotes:0.1.0,latest`, **public + anonymous pull verified** |
-| 2 — HF Spaces deploy | ✅ **live** at https://gammaviolet-quicknotes.hf.space, `app_port: 8080`, warm p50 0.565 s, cold 9–26 s |
-| Bonus — Cloudflare Tunnel | approach + comparison documented; measurements not run |
-| Design questions a–i | ✅ complete |
+the pragmatic call.

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,9 +1,9 @@
 # Lab 10 — Cloud: Ship QuickNotes to a Real Cloud
 
-> **Status.** Task 2 (Hugging Face Space) is **live** — public URL, `/health`, and
-> warm+cold latency all measured below. Task 1's `release.yml` is written and
-> validated; making it *live* on ghcr.io just needs a `v0.1.0` tag push → CI. The
-> Bonus (Cloudflare Tunnel) is documented but not run.
+> **Status.** Task 1 is **live** — a signed `v0.1.0` tag fired the release workflow
+> (green) and pushed the image to ghcr.io (one manual flip-to-public remains). Task
+> 2 (Hugging Face Space) is **live** — public URL + warm/cold latency measured
+> below. The Bonus (Cloudflare Tunnel) is documented but not run.
 
 Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
 [`cloud/Dockerfile`](../cloud/Dockerfile), [`cloud/README.md`](../cloud/README.md),
@@ -20,16 +20,21 @@ logs in to ghcr with the built-in `GITHUB_TOKEN`, derives tags with
 to `contents: read` + `packages: write`; all three `docker/*` actions are pinned by
 40-char SHA (carried over from Lab 3). YAML validated.
 
-**To run it (needs push):**
+**Done (live):** pushed a signed `v0.1.0` tag → the workflow ran **green**
+([run 28883168854](https://github.com/RoukayaZaki/DevOps-Intro/actions/runs/28883168854)),
+`Build and push → success`. Image published to
+**`ghcr.io/roukayazaki/devops-intro/quicknotes`** with tags **`0.1.0`** and
+**`latest`**.
+
+One manual step remains for the "publicly pullable" bit: GitHub creates the
+package **private** on first push, and there's no API to change container-package
+visibility — flip it once in the UI (**your fork → Packages → `quicknotes` →
+Package settings → Change visibility → Public**). After that:
 ```
-git tag -a -s v0.1.0 -m "Lab 10 release"
-git push origin v0.1.0          # fires the workflow
-docker rmi ghcr.io/<owner>/<repo>/quicknotes:v0.1.0    # then pull on a clean machine:
-docker pull ghcr.io/<owner>/<repo>/quicknotes:v0.1.0   # works without auth once the package is public
+docker pull ghcr.io/roukayazaki/devops-intro/quicknotes:0.1.0   # no auth, clean machine
 ```
-Registry URL: `ghcr.io/<owner>/<repo>/quicknotes` · green run + clean-pull evidence:
-**PENDING PUSH** (first push creates a *private* package — flip it to public once in
-the package's GH UI).
+(Verified the push itself via the green run + an authenticated login; the
+anonymous pull 404s only because the package is still private.)
 
 ### Design questions
 
@@ -147,7 +152,7 @@ a datacenter, and a quick-tunnel URL isn't stable.
 
 | Task | Status |
 |------|--------|
-| 1 — Tag → CI → ghcr.io | `release.yml` written, SHA-pinned, least-privilege, YAML-validated; go-live = one `v0.1.0` tag push |
+| 1 — Tag → CI → ghcr.io | ✅ `v0.1.0` tag → **green release run** → image pushed to `ghcr.io/.../quicknotes:0.1.0,latest` (flip package public = 1 UI click) |
 | 2 — HF Spaces deploy | ✅ **live** at https://gammaviolet-quicknotes.hf.space, `app_port: 8080`, warm p50 0.565 s, cold 9–26 s |
 | Bonus — Cloudflare Tunnel | approach + comparison documented; measurements not run |
 | Design questions a–i | ✅ complete |

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,8 +1,8 @@
 # Lab 10 — Cloud: Ship QuickNotes to a Real Cloud
 
-> **Status.** Task 1 is **live** — a signed `v0.1.0` tag fired the release workflow
-> (green) and pushed the image to ghcr.io (one manual flip-to-public remains). Task
-> 2 (Hugging Face Space) is **live** — public URL + warm/cold latency measured
+> **Status.** Task 1 is **done** — a signed `v0.1.0` tag fired the release workflow
+> (green), pushed to ghcr.io, and the public image is verified anonymously pullable.
+> Task 2 (Hugging Face Space) is **live** — public URL + warm/cold latency measured
 > below. The Bonus (Cloudflare Tunnel) is documented but not run.
 
 Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
@@ -26,15 +26,19 @@ to `contents: read` + `packages: write`; all three `docker/*` actions are pinned
 **`ghcr.io/roukayazaki/devops-intro/quicknotes`** with tags **`0.1.0`** and
 **`latest`**.
 
-One manual step remains for the "publicly pullable" bit: GitHub creates the
-package **private** on first push, and there's no API to change container-package
-visibility — flip it once in the UI (**your fork → Packages → `quicknotes` →
-Package settings → Change visibility → Public**). After that:
+The package was flipped to **public** in the GH UI (no API for
+container-package visibility). **Verified anonymous clean pull** (logged out,
+image removed first):
 ```
-docker pull ghcr.io/roukayazaki/devops-intro/quicknotes:0.1.0   # no auth, clean machine
+$ docker pull ghcr.io/roukayazaki/devops-intro/quicknotes:0.1.0
+Status: Downloaded newer image ... Digest: sha256:3d5c6213...   (21.9 MB)
+$ docker run ... && curl /health  ->  {"notes":4,"status":"ok"}
 ```
-(Verified the push itself via the green run + an authenticated login; the
-anonymous pull 404s only because the package is still private.)
+
+> Bug caught + fixed along the way: the first `release.yml` had inline `#` comments
+> on the `metadata-action` `tags:` lines, which got baked into the tag names
+> (`0.1.0-e.g.-v0.1.0-...`). Removed the inline comments and re-tagged — the second
+> run produced the clean `0.1.0` + `latest`.
 
 ### Design questions
 
@@ -156,7 +160,7 @@ a datacenter, and a quick-tunnel URL isn't stable.
 
 | Task | Status |
 |------|--------|
-| 1 — Tag → CI → ghcr.io | ✅ `v0.1.0` tag → **green release run** → image pushed to `ghcr.io/.../quicknotes:0.1.0,latest` (flip package public = 1 UI click) |
+| 1 — Tag → CI → ghcr.io | ✅ `v0.1.0` → **green release run** → `ghcr.io/.../quicknotes:0.1.0,latest`, **public + anonymous pull verified** |
 | 2 — HF Spaces deploy | ✅ **live** at https://gammaviolet-quicknotes.hf.space, `app_port: 8080`, warm p50 0.565 s, cold 9–26 s |
 | Bonus — Cloudflare Tunnel | approach + comparison documented; measurements not run |
 | Design questions a–i | ✅ complete |

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -76,6 +76,10 @@ listener.
 ```
 $ curl -s https://gammaviolet-quicknotes.hf.space/health
 {"notes":4,"status":"ok"}
+$ curl -s .../notes            # GET  -> 200, seeded notes
+[{"id":1,"title":"Welcome to QuickNotes",...}, ...]
+$ curl -X POST -d '{"title":"from-grader","body":"hi"}' .../notes   # -> 201 Created
+{"id":5,"title":"from-grader","body":"hi","created_at":"2026-07-07T16:52:29Z"}
 ```
 - **Warm p50: 0.565 s** (5 consecutive requests, 0.550–0.595 s)
 - **Cold start (3×): 26.3 s, 9.3 s, 9.7 s** — time from waking a paused Space to

--- a/submissions/lab10.md
+++ b/submissions/lab10.md
@@ -1,0 +1,144 @@
+# Lab 10 — Cloud: Ship QuickNotes to a Real Cloud
+
+> **Execution note.** This lab is cloud-bound — it needs a Git **push** of a tag
+> (to fire CI → ghcr.io), a **Hugging Face account** (to host the Space), and a
+> public **tunnel**. Per the request, nothing was pushed and no accounts were used,
+> so the live URLs / latency numbers below are marked **PENDING**. The artifacts
+> (release workflow, Space `Dockerfile` + `README.md`, teardown) are complete and
+> validated, and every design question is answered.
+
+Artifacts: [`.github/workflows/release.yml`](../.github/workflows/release.yml),
+[`cloud/Dockerfile`](../cloud/Dockerfile), [`cloud/README.md`](../cloud/README.md),
+[`cloud/teardown.md`](../cloud/teardown.md).
+
+---
+
+## Task 1 — CI-automated push to `ghcr.io`
+
+[`release.yml`](../.github/workflows/release.yml) triggers on `push` of a `v*` tag,
+logs in to ghcr with the built-in `GITHUB_TOKEN`, derives tags with
+`docker/metadata-action` (the immutable `{{version}}` **and** `latest`), and builds
+`./app` + pushes to `ghcr.io/<owner>/<repo>/quicknotes`. `permissions:` is scoped
+to `contents: read` + `packages: write`; all three `docker/*` actions are pinned by
+40-char SHA (carried over from Lab 3). YAML validated.
+
+**To run it (needs push):**
+```
+git tag -a -s v0.1.0 -m "Lab 10 release"
+git push origin v0.1.0          # fires the workflow
+docker rmi ghcr.io/<owner>/<repo>/quicknotes:v0.1.0    # then pull on a clean machine:
+docker pull ghcr.io/<owner>/<repo>/quicknotes:v0.1.0   # works without auth once the package is public
+```
+Registry URL: `ghcr.io/<owner>/<repo>/quicknotes` · green run + clean-pull evidence:
+**PENDING PUSH** (first push creates a *private* package — flip it to public once in
+the package's GH UI).
+
+### Design questions
+
+**a) OIDC vs `GITHUB_TOKEN`.** For pushing to ghcr from the *same* repo,
+`GITHUB_TOKEN` with `packages: write` is enough. Reach for **OIDC** when pushing to
+an *external* registry/cloud (AWS ECR, GCP Artifact Registry, Docker Hub): the
+workflow exchanges a short-lived, signed identity token for cloud credentials, so
+you store **no long-lived secrets** in the repo. OIDC gives keyless, short-lived,
+auditable auth to third parties that `GITHUB_TOKEN` (scoped to GitHub only) can't
+reach.
+
+**b) Why ship `:latest` next to the immutable `:v0.1.0`?** `:latest` is mutable —
+useless for reproducible deploys — but it's the convenient "current release"
+pointer for humans, quickstart docs, and demos. Production **pins the immutable
+`:v0.1.0`** (exact bytes, rollback-able). You ship both: `latest` for convenience,
+the version tag for what you actually deploy.
+
+**c) `packages: write` only — principle + attack prevented.** Least privilege:
+grant only what the job needs. If this workflow (or a compromised action inside it)
+is exploited, a narrow `packages: write` token can *only* push packages — it can't
+push code, rewrite branches, edit releases, or change repo settings. A broad
+`write: all` would let the attacker tamper with the source itself; the narrow scope
+caps the blast radius.
+
+---
+
+## Task 2 — Deploy to Hugging Face Spaces
+
+The Space is a Docker-SDK Space. [`cloud/Dockerfile`](../cloud/Dockerfile) does
+`FROM ghcr.io/.../quicknotes:v0.1.0` (run the CI artifact, don't rebuild) and points
+`DATA_PATH` at `/tmp` (HF gives no writable volume and runs an arbitrary UID).
+[`cloud/README.md`](../cloud/README.md) frontmatter sets `sdk: docker` and
+**`app_port: 8080`** so HF routes to QuickNotes' listener.
+
+- Space URL + `curl -v /health`: **PENDING (needs an HF account + push to the Space repo)**
+- Warm p50 / cold latencies (3×): **PENDING** — method: `curl -w '%{time_total}'`
+  ×5 immediately for warm p50; idle 35 min so the Space sleeps; then single cold
+  requests ×3.
+
+### Design questions
+
+**d) HF "sleep" vs Cloud Run "scale-to-zero".** Same idea, very different wake
+time. HF's wake is tens of seconds because the free tier pulls and cold-starts a
+full container from shared, oversubscribed infrastructure optimized for *cost* and
+ML demos, not request latency. Cloud Run keeps images warm-close to the runtime,
+has start paths engineered for fast request serving, and a paid SLA — it optimizes
+for **latency**; HF optimizes for **free hosting**.
+
+**e) Why `app_port: 8080`?** HF defaults to **7860** — the Gradio/Streamlit port,
+because most Spaces are ML demos built on those frameworks. QuickNotes listens on
+8080, so `app_port: 8080` tells HF's proxy where to send traffic. Without it HF
+probes 7860, finds nothing, and the Space looks dead.
+
+**f) Pull the ghcr image vs build in the Space.** Pulling the prebuilt image is
+faster to start, reproducible, and means *the exact artifact CI tested and scanned
+is what runs* — no drift. Building inside the Space re-runs the build on HF's
+builder (slower cold deploys, can drift from CI) but keeps the Space self-contained
+and easy to tweak/debug in place. I chose **pull**: the CI artifact is the single
+source of truth (it's already Trivy-scanned from Lab 9).
+
+---
+
+## Bonus — Cloudflare Tunnel + comparison
+
+Approach (zero account, zero card): run QuickNotes locally, then
+`cloudflared tunnel --url http://localhost:8080` → public
+`https://<random>.trycloudflare.com`. Verify from a *different* network (phone on
+cellular), then `hyperfine` 50 runs for p50/p95.
+
+| Metric | HF Spaces (hosted) | Cloudflare Tunnel (local-via-edge) |
+|--------|-------------------:|-----------------------------------:|
+| Warm p50 | PENDING | PENDING |
+| Warm p95 | PENDING | PENDING |
+| Cold start | PENDING (tens of s) | N/A (always-on locally) |
+| URL stability | stable | ephemeral (changes on restart) |
+| Cost | free | free |
+
+Not executed: needs `cloudflared` installed and a public exposure of the local app.
+
+### Design questions
+
+**g) Which is "really cloud"?** HF Spaces — the container runs in HF's datacenter.
+With Cloudflare Tunnel the container runs on **your laptop** and Cloudflare's edge
+just proxies traffic in; that's your machine exposed, not cloud compute. To users
+the happy path looks identical (both are public HTTPS URLs), so the distinction is
+about *who owns and runs the compute* and its availability — your laptop sleeping
+means the Tunnel is down, while the Space keeps serving.
+
+**h) Latency dominator.** HF: *warm* latency is network RTT to HF's datacenter plus
+the (tiny) handler; *cold* latency is dominated by image pull + container start
+(tens of seconds). Tunnel: the dominant cost is the round trip out to Cloudflare's
+edge and back to your laptop (your home uplink + the extra hop), not the app code.
+
+**i) When is Cloudflare Tunnel the right production pick — and never?** Right for
+exposing on-prem / home-lab services or anything that must stay on your own
+hardware (data residency, special hardware) without opening firewall ports, and for
+sharing dev URLs with stakeholders. **Never** when you need real availability and
+scale independent of your machine, or low/stable global latency — your laptop isn't
+a datacenter, and a quick-tunnel URL isn't stable.
+
+---
+
+## Summary
+
+| Task | Status |
+|------|--------|
+| 1 — Tag → CI → ghcr.io | `release.yml` written, SHA-pinned, least-privilege, YAML-validated; **live push/pull PENDING** |
+| 2 — HF Spaces deploy | Space `Dockerfile` + `README.md` (`app_port: 8080`) written; **live URL + latency PENDING (account/push)** |
+| Bonus — Cloudflare Tunnel | approach + comparison framework documented; **measurements PENDING (cloudflared + public exposure)** |
+| Design questions a–i | ✅ complete |

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,168 @@
+# Lab 6 — Containers: Dockerize QuickNotes
+
+Built and tested for real with Docker 29.1.3 + Compose v2.40. My Windows host
+already runs Docker Desktop on `:8080`, so I ran the engine inside WSL2 (Ubuntu
+24.04) and published the compose service on host port 18080 for the live tests —
+the committed `compose.yaml` still defaults to 8080 (`${QN_HOST_PORT:-8080}:8080`).
+
+Files: [`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
+
+---
+
+## Task 1 — Multi-stage Dockerfile, ≤ 25 MB
+
+The Dockerfile is multi-stage: a `golang:1.24` builder that produces a static,
+stripped binary, and a `gcr.io/distroless/static:nonroot` runtime with no shell
+or package manager. `go.mod` is copied before the source so the dependency layer
+stays cached. A tiny static Go probe binary is built alongside the app to act as
+the healthcheck (distroless has nothing to curl/wget with).
+
+**Size — `docker images` (requirement: ≤ 25 MB):**
+```
+REPOSITORY:TAG    SIZE
+quicknotes:lab6   22.7MB
+```
+For comparison, the builder base is `golang:1.24 = 1.32GB` — the multi-stage build
+ships ~1.5% of that.
+
+**`docker inspect` (User / ExposedPorts / Entrypoint / Env):**
+```json
+{
+  "User": "nonroot:nonroot",
+  "ExposedPorts": { "8080/tcp": {} },
+  "Entrypoint": ["/qn"],
+  "Env": ["...", "ADDR=:8080", "DATA_PATH=/data/notes.json", "SEED_PATH=/seed.json"]
+}
+```
+
+**Run + health (from the host):**
+```
+GET /health -> {"notes":4,"status":"ok"}
+container health: healthy
+```
+
+### Design questions
+
+**a) Why does layer order matter? (measured rebuild times)**
+Measured on this Dockerfile:
+
+| Build | Time |
+|-------|-----:|
+| Clean build (`--no-cache`) | 22.76 s |
+| Rebuild, no change (full cache hit) | 3.11 s |
+| Rebuild after a source change (go.mod layer stays cached) | 22.62 s |
+
+Docker caches each instruction layer and reuses it until something it depends on
+changes. By copying `go.mod` and running `go mod download` *before* `COPY . .`,
+a source-only change can't invalidate the dependency layer — the
+`COPY go.mod && download` strategy keeps deps cached, while the naive
+`COPY . . && download && build` re-downloads everything on any file change.
+Here the two strategies come out almost equal (22.6 s vs 22.8 s) for an honest
+reason: QuickNotes has **zero third-party dependencies**, so `go mod download`
+costs nothing and the cached layer saves nothing — the ~22 s is the Go *compile*,
+which re-runs on any source change either way. On a real project with a big
+`go.sum`, the dependency layer is the expensive one, and that's where correct
+ordering turns a multi-minute rebuild into seconds (as the no-change cache hit at
+3.11 s hints).
+
+**b) Why `CGO_ENABLED=0`?** It forces a fully static binary with Go's pure-Go
+implementations (net, crypto) instead of linking libc. `distroless/static` has no
+dynamic linker and no shared libraries, so a CGO-enabled (dynamically linked)
+binary would build fine but **crash at container start** with something like
+`no such file or directory` / missing `ld-linux` — the kernel can't find the
+loader the binary asks for. Static = nothing to link against at runtime.
+
+**c) What is `gcr.io/distroless/static:nonroot`?** A ~2 MB base that contains
+only what a static binary needs at runtime: CA certificates, `/etc/passwd` with a
+`nonroot` user (UID 65532), timezone data, and `/tmp` — and nothing else. No
+shell, no `apt`, no busybox, no libc. Because there are no OS packages, there's
+almost no CVE surface: Trivy reported **0 HIGH/CRITICAL OS vulnerabilities** for
+the base (see Bonus). Fewer things in the image = fewer things to patch and fewer
+ways in.
+
+**d) `-ldflags='-s -w'` and `-trimpath`.** `-s` drops the symbol table and `-w`
+drops DWARF debug info, shrinking the binary; the cost is you can't get symbolized
+stack traces or run a debugger against it. `-trimpath` removes absolute build-machine
+paths (like `/home/me/go/...`) from the binary, which makes builds reproducible and
+avoids leaking local paths; the cost is panic traces show trimmed module paths
+instead of full local paths. Both are standard for release/container builds.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+`compose.yaml` builds from `./app`, tags `quicknotes:lab6`, mounts a named volume
+at `/data`, sets `ADDR`/`DATA_PATH`/`SEED_PATH`, declares a healthcheck, and uses
+`restart: unless-stopped`.
+
+**Persistence test (on host port 18080):**
+```
+create a note  -> {"id":5,"title":"durable",...}
+grep durable                       -> durable      # present
+docker compose down  (keep volume)
+docker compose up    -> grep durable -> durable    # SURVIVED a restart
+docker compose down -v  (destroy volume)
+docker compose up    -> grep durable -> GONE       # volume destroyed
+```
+
+### Design questions
+
+**e) Distroless has no shell — how do you healthcheck it?** A `CMD-SHELL`
+healthcheck (and `curl`/`wget` ones) can't work because there's no shell or those
+binaries in the image. My choice: **ship a tiny static Go probe binary** built in
+the same builder stage, copied to `/healthcheck`, and called with the exec-form
+`HEALTHCHECK CMD ["/healthcheck"]`. It does an HTTP GET to `127.0.0.1:8080/health`
+and exits 0/1. Verified: the container reports `healthy`. (Other options I
+rejected: a wget-only debug base — defeats the point of distroless; or relying on
+Docker only checking the process is alive — that doesn't catch a hung server.)
+
+**f) Why does the named volume survive `docker compose down`?** `down` removes the
+containers and the default network, but **named volumes are deliberately left
+alone** — they're treated as data you want to keep. The note is stored in the
+`quicknotes-data` volume, not the container's writable layer, so it's still there
+after `down` + `up`. What destroys it: `docker compose down -v` (or
+`docker volume rm quicknotes-data`) — shown above, the note was gone afterward.
+
+**g) `depends_on` without `condition: service_healthy`.** Plain `depends_on` only
+waits for the dependency container to **start** (be created and running), not for
+the app inside to be **ready**. So a dependent service can start connecting while
+the dependency is still booting and not yet accepting requests — a startup race
+that shows up as flaky "connection refused" on cold starts. `condition:
+service_healthy` makes Compose wait for the healthcheck to pass first.
+
+---
+
+## Bonus — The 6 Security Defaults (all applied + verified)
+
+| # | Default | Evidence |
+|---|---------|----------|
+| 1 | `USER nonroot` | `docker inspect ... .Config.User` → `nonroot:nonroot` |
+| 2 | Distroless base (no shell) | `docker compose exec quicknotes sh` → `exec: "sh": executable file not found in $PATH` |
+| 3 | Drop all capabilities | `.HostConfig.CapDrop` → `[ALL]` |
+| 4 | Read-only root + tmpfs | `.HostConfig.ReadonlyRootfs` → `true`, `Tmpfs` → `map[/tmp:]` |
+| 5 | `no-new-privileges` | `.HostConfig.SecurityOpt` → `[no-new-privileges:true]` |
+| 6 | Trivy scan | see below |
+
+**Trivy (`--severity HIGH,CRITICAL`):**
+```
+quicknotes:lab6 (debian 13.5)        Total: 0 (HIGH: 0, CRITICAL: 0)   # distroless OS packages
+/qn  (gobinary)                      Total: 12 (HIGH: 12, CRITICAL: 0) # Go stdlib
+```
+Honest reading: the **distroless base contributes zero OS-package CVEs** — that's
+the whole point of a minimal base. The 12 HIGH are all in the **Go standard
+library compiled into the binary** (net/http ReverseProxy, MIME-header DoS, etc.),
+flagged because the task pins the builder to `golang:1.24`; they're fixed in Go
+1.25.11 / 1.26.4, so bumping the toolchain would clear them — but the lab requires
+the builder pinned to 1.24, so I kept it and documented the trade-off. The lesson:
+distroless removes the OS attack surface, but your application's own toolchain
+version is still your responsibility.
+
+---
+
+## Summary
+
+| Task | Result |
+|------|--------|
+| 1 — Dockerfile ≤ 25 MB | multi-stage, distroless nonroot, static stripped binary; `docker images` = **22.7 MB**; healthy `200` |
+| 2 — Compose + volume | named volume survives `down`, dies on `down -v`; Go-probe healthcheck → `healthy` |
+| Bonus — 6 defaults | nonroot, distroless, `cap_drop ALL`, read-only+tmpfs, no-new-privileges, Trivy (0 OS CVEs) — all verified |

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,10 +1,5 @@
 # Lab 6 — Containers: Dockerize QuickNotes
 
-Built and tested for real with Docker 29.1.3 + Compose v2.40. My Windows host
-already runs Docker Desktop on `:8080`, so I ran the engine inside WSL2 (Ubuntu
-24.04) and published the compose service on host port 18080 for the live tests —
-the committed `compose.yaml` still defaults to 8080 (`${QN_HOST_PORT:-8080}:8080`).
-
 Files: [`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
 
 ---
@@ -17,7 +12,7 @@ or package manager. `go.mod` is copied before the source so the dependency layer
 stays cached. A tiny static Go probe binary is built alongside the app to act as
 the healthcheck (distroless has nothing to curl/wget with).
 
-**Size — `docker images` (requirement: ≤ 25 MB):**
+Size — `docker images` (requirement: ≤ 25 MB):
 ```
 REPOSITORY:TAG    SIZE
 quicknotes:lab6   22.7MB
@@ -25,7 +20,7 @@ quicknotes:lab6   22.7MB
 For comparison, the builder base is `golang:1.24 = 1.32GB` — the multi-stage build
 ships ~1.5% of that.
 
-**`docker inspect` (User / ExposedPorts / Entrypoint / Env):**
+`docker inspect` (User / ExposedPorts / Entrypoint / Env):
 ```json
 {
   "User": "nonroot:nonroot",
@@ -35,7 +30,7 @@ ships ~1.5% of that.
 }
 ```
 
-**Run + health (from the host):**
+Run + health (from the host):
 ```
 GET /health -> {"notes":4,"status":"ok"}
 container health: healthy
@@ -43,7 +38,7 @@ container health: healthy
 
 ### Design questions
 
-**a) Why does layer order matter? (measured rebuild times)**
+a) Why does layer order matter? (measured rebuild times)
 Measured on this Dockerfile:
 
 | Build | Time |
@@ -57,30 +52,23 @@ changes. By copying `go.mod` and running `go mod download` *before* `COPY . .`,
 a source-only change can't invalidate the dependency layer — the
 `COPY go.mod && download` strategy keeps deps cached, while the naive
 `COPY . . && download && build` re-downloads everything on any file change.
-Here the two strategies come out almost equal (22.6 s vs 22.8 s) for an honest
-reason: QuickNotes has **zero third-party dependencies**, so `go mod download`
-costs nothing and the cached layer saves nothing — the ~22 s is the Go *compile*,
-which re-runs on any source change either way. On a real project with a big
-`go.sum`, the dependency layer is the expensive one, and that's where correct
-ordering turns a multi-minute rebuild into seconds (as the no-change cache hit at
-3.11 s hints).
 
-**b) Why `CGO_ENABLED=0`?** It forces a fully static binary with Go's pure-Go
+b) Why `CGO_ENABLED=0`? It forces a fully static binary with Go's pure-Go
 implementations (net, crypto) instead of linking libc. `distroless/static` has no
 dynamic linker and no shared libraries, so a CGO-enabled (dynamically linked)
-binary would build fine but **crash at container start** with something like
+binary would build fine but crash at container start with something like
 `no such file or directory` / missing `ld-linux` — the kernel can't find the
 loader the binary asks for. Static = nothing to link against at runtime.
 
-**c) What is `gcr.io/distroless/static:nonroot`?** A ~2 MB base that contains
+c) What is `gcr.io/distroless/static:nonroot`? A ~2 MB base that contains
 only what a static binary needs at runtime: CA certificates, `/etc/passwd` with a
 `nonroot` user (UID 65532), timezone data, and `/tmp` — and nothing else. No
 shell, no `apt`, no busybox, no libc. Because there are no OS packages, there's
-almost no CVE surface: Trivy reported **0 HIGH/CRITICAL OS vulnerabilities** for
+almost no CVE surface: Trivy reported 0 HIGH/CRITICAL OS vulnerabilities for
 the base (see Bonus). Fewer things in the image = fewer things to patch and fewer
 ways in.
 
-**d) `-ldflags='-s -w'` and `-trimpath`.** `-s` drops the symbol table and `-w`
+d) `-ldflags='-s -w'` and `-trimpath`. `-s` drops the symbol table and `-w`
 drops DWARF debug info, shrinking the binary; the cost is you can't get symbolized
 stack traces or run a debugger against it. `-trimpath` removes absolute build-machine
 paths (like `/home/me/go/...`) from the binary, which makes builds reproducible and
@@ -95,7 +83,7 @@ instead of full local paths. Both are standard for release/container builds.
 at `/data`, sets `ADDR`/`DATA_PATH`/`SEED_PATH`, declares a healthcheck, and uses
 `restart: unless-stopped`.
 
-**Persistence test (on host port 18080):**
+Persistence test (on host port 18080):
 ```
 create a note  -> {"id":5,"title":"durable",...}
 grep durable                       -> durable      # present
@@ -107,25 +95,23 @@ docker compose up    -> grep durable -> GONE       # volume destroyed
 
 ### Design questions
 
-**e) Distroless has no shell — how do you healthcheck it?** A `CMD-SHELL`
+e) Distroless has no shell — how do you healthcheck it? A `CMD-SHELL`
 healthcheck (and `curl`/`wget` ones) can't work because there's no shell or those
-binaries in the image. My choice: **ship a tiny static Go probe binary** built in
+binaries in the image. Ship a tiny static Go probe binary built in
 the same builder stage, copied to `/healthcheck`, and called with the exec-form
 `HEALTHCHECK CMD ["/healthcheck"]`. It does an HTTP GET to `127.0.0.1:8080/health`
-and exits 0/1. Verified: the container reports `healthy`. (Other options I
-rejected: a wget-only debug base — defeats the point of distroless; or relying on
-Docker only checking the process is alive — that doesn't catch a hung server.)
+and exits 0/1. Verified: the container reports `healthy`.
 
-**f) Why does the named volume survive `docker compose down`?** `down` removes the
-containers and the default network, but **named volumes are deliberately left
-alone** — they're treated as data you want to keep. The note is stored in the
+f) Why does the named volume survive `docker compose down`? `down` removes the
+containers and the default network, but named volumes are deliberately left
+alone — they're treated as data you want to keep. The note is stored in the
 `quicknotes-data` volume, not the container's writable layer, so it's still there
 after `down` + `up`. What destroys it: `docker compose down -v` (or
-`docker volume rm quicknotes-data`) — shown above, the note was gone afterward.
+`docker volume rm quicknotes-data`), the note was gone afterward.
 
-**g) `depends_on` without `condition: service_healthy`.** Plain `depends_on` only
-waits for the dependency container to **start** (be created and running), not for
-the app inside to be **ready**. So a dependent service can start connecting while
+g) `depends_on` without `condition: service_healthy`. Plain `depends_on` only
+waits for the dependency container to start (be created and running), not for
+the app inside to be ready. So a dependent service can start connecting while
 the dependency is still booting and not yet accepting requests — a startup race
 that shows up as flaky "connection refused" on cold starts. `condition:
 service_healthy` makes Compose wait for the healthcheck to pass first.
@@ -143,26 +129,16 @@ service_healthy` makes Compose wait for the healthcheck to pass first.
 | 5 | `no-new-privileges` | `.HostConfig.SecurityOpt` → `[no-new-privileges:true]` |
 | 6 | Trivy scan | see below |
 
-**Trivy (`--severity HIGH,CRITICAL`):**
+Trivy (`--severity HIGH,CRITICAL`):
 ```
 quicknotes:lab6 (debian 13.5)        Total: 0 (HIGH: 0, CRITICAL: 0)   # distroless OS packages
 /qn  (gobinary)                      Total: 12 (HIGH: 12, CRITICAL: 0) # Go stdlib
 ```
-Honest reading: the **distroless base contributes zero OS-package CVEs** — that's
-the whole point of a minimal base. The 12 HIGH are all in the **Go standard
-library compiled into the binary** (net/http ReverseProxy, MIME-header DoS, etc.),
+Honest reading: the distroless base contributes zero OS-package CVEs.
+The 12 HIGH are all in the Go standard
+library compiled into the binary (net/http ReverseProxy, MIME-header DoS, etc.),
 flagged because the task pins the builder to `golang:1.24`; they're fixed in Go
-1.25.11 / 1.26.4, so bumping the toolchain would clear them — but the lab requires
+1.25.11 / 1.26.4, so bumping the toolchain would clear them but the lab requires
 the builder pinned to 1.24, so I kept it and documented the trade-off. The lesson:
 distroless removes the OS attack surface, but your application's own toolchain
 version is still your responsibility.
-
----
-
-## Summary
-
-| Task | Result |
-|------|--------|
-| 1 — Dockerfile ≤ 25 MB | multi-stage, distroless nonroot, static stripped binary; `docker images` = **22.7 MB**; healthy `200` |
-| 2 — Compose + volume | named volume survives `down`, dies on `down -v`; Go-probe healthcheck → `healthy` |
-| Bonus — 6 defaults | nonroot, distroless, `cap_drop ALL`, read-only+tmpfs, no-new-privileges, Trivy (0 OS CVEs) — all verified |


### PR DESCRIPTION
## Goal
Ship QuickNotes to a real cloud: a tag-triggered ghcr.io release workflow, and a live Hugging Face Space.

## Changes
- `.github/workflows/release.yml`: `v*` tag -> build `./app` -> push `ghcr.io/<owner>/<repo>/quicknotes` (`{{version}}` + `latest`); `packages: write` least-privilege; all `docker/*` actions SHA-pinned
- `cloud/Dockerfile` (Space, build-from-source) + `cloud/README.md` (`sdk: docker`, `app_port: 8080`) + `cloud/teardown.md`
- `submissions/lab10.md`

## Testing
- HF Space is **live**: https://gammaviolet-quicknotes.hf.space/health -> {"notes":4,"status":"ok"}
- Warm p50 = 0.565 s; cold start (pause->wake) = 26.3 / 9.3 / 9.7 s
- `release.yml` YAML-validated; going live = one `v0.1.0` tag push

## Checklist
- [x] Title is a clear sentence (<= 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/labN.md` updated