### PR TITLE
feat(lab11): reproducible Nix flake + deterministic OCI image

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+-
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (<= 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: quicknotes-ci
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - app/**
+      - .github/workflows/ci.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - app/**
+      - .github/workflows/ci.yml
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: app
+
+jobs:
+  vet:
+    name: vet (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.23"
+          - "1.24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Run go vet
+        run: go vet ./...
+
+  test:
+    name: test (go ${{ matrix.go-version }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - "1.23"
+          - "1.24"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Run tests with race detector
+        run: go test -race -count=1 ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.24"
+          cache: true
+          cache-dependency-path: app/go.sum
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+      - name: Run golangci-lint
+        run: golangci-lint run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Run go vet
         run: go vet ./...
 
@@ -60,7 +60,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Run tests with race detector
         run: go test -race -count=1 ./...
 
@@ -75,7 +75,7 @@ jobs:
         with:
           go-version: "1.24"
           cache: true
-          cache-dependency-path: app/go.sum
+          cache-dependency-path: app/go.mod
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
       - name: Run golangci-lint

--- a/.github/workflows/nix-repro.yml
+++ b/.github/workflows/nix-repro.yml
@@ -1,0 +1,85 @@
+name: nix-repro
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-a:
+    name: build-a
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Optionally break reproducibility (demo red runs only)
+        if: vars.NIX_REPRO_BREAK == 'true'
+        env:
+          SOURCE_DATE_EPOCH: "0"
+        run: |
+          # Lab 11 B.3: diverge job A. Pure Nix ignores SOURCE_DATE_EPOCH alone,
+          # so also rewrite the image tag (and set SOURCE_DATE_EPOCH for the log).
+          echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
+          sed -i 's/tag = "lab11"/tag = "lab11-break"/' flake.nix
+
+      - name: Build OCI image
+        run: nix build .#docker --print-build-logs
+
+      - name: Compute digest
+        id: digest
+        run: |
+          DIGEST=$(sha256sum result | awk '{print $1}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "build-a digest=$DIGEST"
+
+  build-b:
+    name: build-b
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Build OCI image
+        run: nix build .#docker --print-build-logs
+
+      - name: Compute digest
+        id: digest
+        run: |
+          DIGEST=$(sha256sum result | awk '{print $1}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "build-b digest=$DIGEST"
+
+  compare:
+    name: assert-equal-digests
+    needs: [build-a, build-b]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Compare digests from both runners
+        env:
+          DIGEST_A: ${{ needs.build-a.outputs.digest }}
+          DIGEST_B: ${{ needs.build-b.outputs.digest }}
+        run: |
+          echo "digest-a=$DIGEST_A"
+          echo "digest-b=$DIGEST_B"
+          if [ -z "$DIGEST_A" ] || [ -z "$DIGEST_B" ]; then
+            echo "missing digest output(s)"
+            exit 1
+          fi
+          if [ "$DIGEST_A" != "$DIGEST_B" ]; then
+            echo "DIGEST MISMATCH — builds are not reproducible across runners"
+            exit 1
+          fi
+          echo "digests match"

--- a/.github/workflows/nix-repro.yml
+++ b/.github/workflows/nix-repro.yml
@@ -3,6 +3,7 @@ name: nix-repro
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod ./
+COPY go.sum* ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -trimpath \
+    -ldflags='-s -w' \
+    -o /out/quicknotes .
+
+RUN mkdir -p /tmp/healthcheck && \
+    printf '%s\n' \
+      'package main' \
+      '' \
+      'import (' \
+      '	"net/http"' \
+      '	"os"' \
+      ')' \
+      '' \
+      'func main() {' \
+      '	resp, err := http.Get("http://127.0.0.1:8080/health")' \
+      '	if err != nil || resp.StatusCode != http.StatusOK {' \
+      '		os.Exit(1)' \
+      '	}' \
+      '}' \
+      > /tmp/healthcheck/main.go && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+      -trimpath \
+      -ldflags='-s -w' \
+      -o /out/healthcheck /tmp/healthcheck/main.go
+
+RUN mkdir -p /empty-data && chown 65532:65532 /empty-data
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /out/quicknotes /quicknotes
+COPY --from=builder /out/healthcheck /healthcheck
+COPY seed.json /seed.json
+COPY --from=builder --chown=65532:65532 /empty-data /data
+
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/quicknotes"]
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/healthcheck"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: "0.0.0.0:8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,136 @@
+{
+  description = "QuickNotes — reproducible Nix flake (Lab 11)";
+
+  inputs = {
+    # nixos-24.11 ships Go 1.23; QuickNotes go.mod requires >= 1.24.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      mkQuicknotes =
+        pkgs:
+        pkgs.buildGoModule {
+          pname = "quicknotes";
+          version = "0.1.0";
+
+          src = pkgs.lib.cleanSourceWith {
+            src = ./app;
+            filter =
+              path: type:
+              let
+                base = baseNameOf path;
+              in
+              !(builtins.elem base [
+                "quicknotes"
+                "data"
+                "result"
+              ]);
+          };
+
+          # Stdlib-only module: no Go deps to vendor.
+          # nixos-25.05 buildGoModule requires vendorHash = null when the vendor tree is empty
+          # (a non-null empty hash fails with "vendor folder is empty").
+          vendorHash = null;
+
+          env.CGO_ENABLED = "0";
+          ldflags = [
+            "-s"
+            "-w"
+          ];
+
+          meta = {
+            description = "QuickNotes HTTP notes API";
+            mainProgram = "quicknotes";
+          };
+        };
+
+      # Minimal passwd/group so the container can run as Lab 6's nonroot UID 65532.
+      nonrootPasswd = pkgs: ''
+        root:x:0:0::/root:/sbin/nologin
+        nonroot:x:65532:65532::/home/nonroot:/sbin/nologin
+        nobody:x:65534:65534::/:/sbin/nologin
+      '';
+      nonrootGroup = pkgs: ''
+        root:x:0:
+        nonroot:x:65532:
+        nogroup:x:65534:
+      '';
+
+      mkDocker =
+        pkgs: quicknotes:
+        pkgs.dockerTools.buildImage {
+          name = "quicknotes";
+          tag = "lab11";
+          copyToRoot = pkgs.buildEnv {
+            name = "quicknotes-image-root";
+            paths = [
+              quicknotes
+              pkgs.dockerTools.caCertificates
+              (pkgs.writeTextDir "etc/passwd" (nonrootPasswd pkgs))
+              (pkgs.writeTextDir "etc/group" (nonrootGroup pkgs))
+            ];
+            pathsToLink = [
+              "/bin"
+              "/etc"
+            ];
+          };
+          config = {
+            Entrypoint = [ "/bin/quicknotes" ];
+            ExposedPorts = {
+              "8080/tcp" = { };
+            };
+            User = "65532:65532";
+            Env = [
+              "ADDR=0.0.0.0:8080"
+              "DATA_PATH=/tmp/notes.json"
+              "SEED_PATH=/seed.json"
+            ];
+            WorkingDir = "/";
+          };
+          extraCommands = ''
+            mkdir -p -m 1777 tmp
+            cp ${./app/seed.json} seed.json
+          '';
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          quicknotes = mkQuicknotes pkgs;
+          docker = mkDocker pkgs quicknotes;
+        in
+        {
+          inherit quicknotes docker;
+          default = quicknotes;
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              pkgs.go
+              pkgs.gopls
+              pkgs.golangci-lint
+            ];
+          };
+        }
+      );
+    };
+}

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,169 @@
+# Lab 11 Submission — Reproducible Builds with Nix
+
+## Task 1 — Reproducible Go build via flake (4 pts)
+
+### `flake.nix`
+
+Pinned to `nixpkgs/nixos-25.05` (not `24.11`) because QuickNotes `go.mod` requires Go ≥ 1.24 and `24.11` only ships Go 1.23. Lockfile: [`flake.lock`](../flake.lock).
+
+Uses `buildGoModule` (stdlib-only module → `vendorHash = null`), `env.CGO_ENABLED = "0"`, `ldflags = [ "-s" "-w" ]`, packages `quicknotes` / `default`, and a `devShell` with `go` / `gopls` / `golangci-lint`.
+
+Full file: [`flake.nix`](../flake.nix).
+
+### Build log excerpt (`nix build .#quicknotes`)
+
+```text
+building '/nix/store/...-quicknotes-0.1.0.drv'...
+quicknotes> Building subPackage .
+quicknotes> ok          quicknotes      0.014s
+quicknotes> ...
+```
+
+Binary: `/nix/store/...-quicknotes-0.1.0/bin/quicknotes` (~5.6 MB static).
+
+### Two independent store hashes (must match)
+
+| Env | How | `nix-store --query --hash $(readlink result)` |
+|-----|-----|-----------------------------------------------|
+| **A** | `docker run nixos/nix:2.24.12` container `#1` | `sha256:1z6fc78k06d931jpv8r795010mm4k6kizd1nkkdrcv97anr8ma7s` |
+| **B** | fresh `nixos/nix:2.24.12` container `#2` (separate `/nix`) | `sha256:1z6fc78k06d931jpv8r795010mm4k6kizd1nkkdrcv97anr8ma7s` |
+
+Hashes are **identical**.
+
+### Runtime proof
+
+```text
+$ ./result/bin/quicknotes &
+$ curl -s http://127.0.0.1:8080/health
+{"notes":0,"status":"ok"}
+```
+
+### Design questions (a–d)
+
+**a) Why isn't `go build` bit-identical across machines?**  
+Toolchains embed build IDs / paths, timestamps can leak into archives/metadata, and module resolution can float without a lock. Two laptops with "Go 1.24" can still differ in patch level, `GOROOT`, and cgo linkage. Nix pins the exact Go derivation + src hash, so the store path (and contents) match.
+
+**b) What is `vendorHash`? What if `null`?**  
+`vendorHash` is the fixed-output hash of the Go module download / vendor tree Nix fetches before compiling. If wrong, the build fails with the expected `got:` hash. `vendorHash = null` skips that fixed-output derivation and allows a non-vendored fetch — required here because the module has **no third-party deps** (`go: no dependencies to vendor`; a non-null empty hash errors with "vendor folder is empty" on nixos-25.05).
+
+**c) Why is `flake.lock` critical?**  
+It pins nixpkgs (and every flake input) to a precise Git revision + NAR hash. Delete it before a second build and evaluation may resolve a newer `nixos-25.05` tip → different Go/compiler → different outputs. Commit of `flake.lock` is the reproducibility contract.
+
+**d) `buildGoModule` vs `buildGoApplication`?**  
+`buildGoModule` is in nixpkgs proper and vendoring/`vendorHash`-based. `buildGoApplication` (gomod2nix) generates Nix from `go.mod` for richer graph control. For a tiny stdlib-only QuickNotes binary, `buildGoModule` is enough and simpler — one file, no generators.
+
+---
+
+## Task 2 — Deterministic OCI image (4 pts)
+
+### Flake package `docker`
+
+`pkgs.dockerTools.buildImage` wraps the Task 1 binary:
+
+- `Entrypoint = [ "/bin/quicknotes" ]`
+- `ExposedPorts."8080/tcp"`
+- `User = "65532:65532"` (Lab 6 nonroot UID) + minimal `/etc/passwd`/`group`
+- Built **without Docker** — only Nix
+
+### Load + health
+
+```text
+$ docker load < result
+$ docker run --rm -p 18080:8080 quicknotes:lab11
+$ curl -s http://127.0.0.1:18080/health
+{"notes":4,"status":"ok"}
+
+User=65532:65532 Entrypoint=["/bin/quicknotes"] Exposed={"8080/tcp":{}}
+```
+
+### Two independent image digests (must match)
+
+```text
+# Env A (container #1)
+6c796a77aeceec80f72d3a5b4a3b566306b7739c2f698d30af75e3403d90ed25  result-docker
+
+# Env B (fresh container #2)
+6c796a77aeceec80f72d3a5b4a3b566306b7739c2f698d30af75e3403d90ed25  result-docker-B
+```
+
+Identical SHA-256 of the OCI tarball.
+
+### Image size: Nix vs Lab 6 Docker
+
+| Image | Size (docker images) | Notes |
+|-------|----------------------|-------|
+| `quicknotes:lab11` (Nix `dockerTools`) | **23.1 MB** | tarball on disk ~3.3 MB gzip |
+| `qn-lab6:run1` / `run2` (Dockerfile) | **22.5 MB** | distroless + static binary |
+
+Sizes are in the same ballpark; the Nix image carries ca-certs + fake passwd. The win is **digest stability**, not size.
+
+### Lab 6 `--no-cache` digests differ
+
+```text
+$ docker build --no-cache -t qn-lab6:run1 ./app
+$ docker build --no-cache -t qn-lab6:run2 ./app
+$ docker images --no-trunc qn-lab6
+
+qn-lab6:run1 sha256:16978dd27b75f7126240e7bacbc3909d1f59d494016279369b2afa6b7c534146 22.5MB
+qn-lab6:run2 sha256:8b48c237c5981bf9d04a097e1b4e4bb92e6f07643c23874e5e173f42a13aa98d 22.5MB
+```
+
+Same Dockerfile, same tree — **different** image IDs (timestamps / non-reproducible layers).
+
+### Design questions (e–g)
+
+**e) What makes `docker build` non-deterministic?**  
+Layer metadata timestamps, base image tags that move (`alpine`/`golang` digests change), `apt`/`apk` indexes resolving "today's" packages, build-cache opacity, and Go/buildkit IDs. Even `--no-cache` from one Git SHA usually yields a new image ID each run (as shown above).
+
+**f) What can a security auditor prove with a reproducible image that a signed-but-non-reproducible one cannot?**  
+Signature proves *who* published a blob. Reproducibility proves *what* was built matches *public source* independently. A malicious CI can sign a backdoored blob; independent rebuilds failing to match the signed digest expose the lie (xz-utils lesson).
+
+**g) Trade-off — why is `docker build` still default?**  
+Nix has a steep learning curve, slower cold builds without a binary cache, and awkward packaging for some ecosystems. Dockerfiles are familiar, Hub-cached, and "good enough" for most teams that prioritize ship-speed over bit-identity.
+
+---
+
+## Bonus — CI-verified reproducibility (2 pts)
+
+### Workflow
+
+[`.github/workflows/nix-repro.yml`](../.github/workflows/nix-repro.yml):
+
+- Triggers on push + pull_request
+- Parallel jobs `build-a` / `build-b` on fresh `ubuntu-24.04` runners
+- Determinate Nix installer pinned by SHA (`ef8a1480…` = v22)
+- Each job: `nix build .#docker` → `sha256sum result`
+- Job `compare` fails if digests differ
+
+Deliberate break (B.3): repository variable `NIX_REPRO_BREAK=true` makes job A rewrite `tag = "lab11-break"` (and set `SOURCE_DATE_EPOCH=0`). Pure Nix ignores ambient `SOURCE_DATE_EPOCH` alone, so the tag rewrite is what forces a visible mismatch.
+
+### CI evidence
+
+*(filled after push — green run URL + red run with BREAK=true)*
+
+### Design questions (h–j)
+
+**h) Laptop vs CI proof**  
+Laptop proof can share a warm store, same LAN mirrors, and accidental impurities you never notice. CI on two fresh runners is what an auditor can cite: independent evaluation without your laptop's `/nix/store` residue.
+
+**i) Why two parallel jobs, not one job twice?**  
+A single job reuses the same runner filesystem, Nix daemon, and cache. Shared state can hide machine-specific leaks (locale, leftover `/tmp`, cached impure inputs). Two parallel fresh VMs closer to "two independent machines."
+
+**j) `SOURCE_DATE_EPOCH` and `dockerTools`**  
+Timestamps normally leak into tarball members / image JSON. Nix sets a fixed epoch inside the sandbox; `dockerTools.buildImage` produces layers with deterministic mtimes. A host `SOURCE_DATE_EPOCH` does not rewrite a pure derivation — hence the explicit tag rewrite for the red CI demo.
+
+---
+
+## How to reproduce
+
+```bash
+# Requires Nix with flakes (or: docker run --rm -v "$PWD":/repo -w /repo nixos/nix:2.24.12)
+nix build .#quicknotes
+nix-store --query --hash "$(readlink result)"
+./result/bin/quicknotes &
+curl -s localhost:8080/health
+
+nix build .#docker
+sha256sum result
+docker load < result
+```

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -139,7 +139,19 @@ Deliberate break (B.3): repository variable `NIX_REPRO_BREAK=true` makes job A r
 
 ### CI evidence
 
-*(filled after push — green run URL + red run with BREAK=true)*
+| Run | Result | URL |
+|-----|--------|-----|
+| Green (equal digests) | **success** — `assert-equal-digests` passed | https://github.com/IlyaPechersky/DevOps-Intro/actions/runs/29335118114 |
+| Red (`NIX_REPRO_BREAK=true` diverges job A) | **failure** — digest mismatch | https://github.com/IlyaPechersky/DevOps-Intro/actions/runs/29335384822 |
+
+Red compare log excerpt:
+```text
+digest-a=05039121bb65454ee5b4de5a7e2ec86815f51219a8934c3db978966351eb2fea
+digest-b=6c796a77aeceec80f72d3a5b4a3b566306b7739c2f698d30af75e3403d90ed25
+DIGEST MISMATCH — builds are not reproducible across runners
+```
+
+Green compare log: both cells reported the same digest as the local Nix tarball (`6c796a77aeceec80f72d3a5b4a3b566306b7739c2f698d30af75e3403d90ed25`).
 
 ### Design questions (h–j)
 

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,205 @@
+# Lab 6 Submission
+
+Host used for the run: Ubuntu 24.04.3 LTS x86_64 cloud server with Docker 29.4.2 and Compose v5.1.3.
+
+## Task 1 - Multi-Stage Dockerfile
+
+`app/Dockerfile` is committed in the repository. Key points:
+
+- Builder: `golang:1.24-alpine`
+- Runtime: `gcr.io/distroless/static-debian12:nonroot`
+- Static build with `CGO_ENABLED=0`, `-trimpath`, `-ldflags='-s -w'`
+- `USER nonroot:nonroot`, `EXPOSE 8080`, exec-form `ENTRYPOINT`
+- `go.mod` copied before source for layer caching
+- A tiny static `/healthcheck` binary is built in the builder stage for HTTP probes
+- `/data` is seeded in the image with UID 65532 so named volumes inherit writable ownership
+
+Build and image size:
+
+```text
+$ docker build -t quicknotes:lab6 ./app
+...
+$ docker images quicknotes:lab6
+IMAGE             ID             DISK USAGE   CONTENT SIZE   EXTRA
+quicknotes:lab6   f63a1637227a       22.5MB          5.6MB
+
+$ docker images golang:1.24-alpine
+IMAGE                ID             DISK USAGE   CONTENT SIZE   EXTRA
+golang:1.24-alpine   8bee1901f1e5        395MB         83.5MB
+```
+
+`docker inspect` excerpt:
+
+```text
+User=nonroot:nonroot
+ExposedPorts={"8080/tcp":{}}
+Entrypoint=["/quicknotes"]
+Healthcheck={"Test":["CMD","/healthcheck"],"Interval":10000000000,"Timeout":3000000000,"StartPeriod":5000000000,"Retries":3}
+```
+
+Runtime verification:
+
+```text
+$ docker run -d --name qn-lab6-run -p 18081:8080 \
+  -e ADDR=0.0.0.0:8080 -e DATA_PATH=/data/notes.json -e SEED_PATH=/seed.json \
+  -v qn-lab6-run-data:/data quicknotes:lab6
+$ curl -s http://127.0.0.1:18081/health
+{"notes":4,"status":"ok"}
+```
+
+### Layer-cache comparison
+
+Bad order (`COPY . .` before `go mod download`), rebuild after touching one source file:
+
+```text
+#10 [builder 4/5] RUN go mod download
+#12 [builder 5/5] RUN CGO_ENABLED=0 ... go build ...
+real 0.72
+```
+
+Good order (`COPY go.mod` + `go mod download` before `COPY . .`), rebuild after the same change:
+
+```text
+#20 [builder 5/9] RUN go mod download
+#20 CACHED
+#17 [builder 7/9] RUN CGO_ENABLED=0 ... go build ...
+real 1.30
+```
+
+The bad Dockerfile invalidates dependency download on every source edit. The good Dockerfile keeps `go mod download` cached and only rebuilds the binary layer.
+
+### Design answers
+
+a) Layer order matters because Docker caches each instruction. Putting `COPY . .` before `go mod download` ties the dependency layer to every source change, so `go mod download` reruns even when `go.mod` is unchanged. Copying `go.mod` first keeps dependency download cached across normal code edits.
+
+b) `CGO_ENABLED=0` produces a fully static binary with no libc dependency. Distroless static has no dynamic linker; a CGO-enabled binary fails at startup with errors like `no such file or directory` when the loader is missing.
+
+c) `gcr.io/distroless/static:nonroot` is a minimal runtime image with just the app, CA certs, `/etc/passwd`, and timezone data. It has no shell, package manager, or extra utilities. Fewer packages means a much smaller attack surface and fewer OS-level CVEs to patch.
+
+d) `-s -w` strips the symbol table and DWARF debug info to shrink the binary. `-trimpath` removes local filesystem paths from the binary for reproducible builds. The cost is harder post-mortem debugging from the stripped binary alone.
+
+## Task 2 - Compose + Healthcheck + Persistent Volume
+
+Root `compose.yaml`:
+
+```yaml
+services:
+  quicknotes:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: "0.0.0.0:8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:
+```
+
+Persistence test:
+
+```text
+$ docker compose up --build -d
+$ curl -s http://127.0.0.1:8080/health
+{"notes":4,"status":"ok"}
+
+$ curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"title":"durable","body":"survive a restart"}' \
+  http://127.0.0.1:8080/notes
+{"id":5,"title":"durable","body":"survive a restart","created_at":"2026-06-23T20:27:39.237347063Z"}
+
+--- after POST ---
+$ curl -s http://127.0.0.1:8080/notes | grep durable
+..."title":"durable"...
+
+$ docker compose down
+$ docker compose up -d
+
+--- after down/up ---
+$ curl -s http://127.0.0.1:8080/notes | grep durable
+..."title":"durable"...
+
+$ docker compose down -v
+$ docker compose up -d
+
+--- after down -v ---
+durable gone (expected)
+```
+
+Compose status after startup:
+
+```text
+NAME                       IMAGE             STATUS                    PORTS
+devops-lab6-quicknotes-1   quicknotes:lab6   Up 12 seconds (healthy)   0.0.0.0:8080->8080/tcp
+```
+
+### Design answers
+
+e) Distroless has no shell, so a shell-form healthcheck cannot work. I built a tiny static `/healthcheck` binary in the builder stage and use exec-form `CMD ["/healthcheck"]` to call `http://127.0.0.1:8080/health`. That gives a real HTTP probe without adding a shell to the runtime image.
+
+f) `volumes: [quicknotes-data:/data]` survives `docker compose down` because Compose removes containers and networks, not named volumes. The data stays in Docker's volume store until `docker compose down -v`, `docker volume rm`, or `docker volume prune`.
+
+g) `depends_on` without `condition: service_healthy` only waits for the dependency container to start, not for the app inside it to be ready. A dependent service can send traffic before QuickNotes is listening and see connection errors.
+
+## Bonus - 6 Security Defaults
+
+Hardened `services.quicknotes` block is shown above (`cap_drop`, `read_only`, `tmpfs`, `security_opt`, nonroot image, distroless base).
+
+Verification:
+
+```text
+$ docker inspect quicknotes:lab6 --format '{{ .Config.User }}'
+nonroot:nonroot
+
+$ docker compose exec quicknotes sh
+OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH
+
+$ docker inspect <container> --format '{{ .HostConfig.CapDrop }}'
+[ALL]
+
+$ docker inspect <container> --format '{{ .HostConfig.ReadonlyRootfs }}'
+true
+
+$ docker inspect <container> --format '{{ .HostConfig.SecurityOpt }}'
+[no-new-privileges:true]
+
+$ docker inspect <container> --format '{{json .State.Health.Status}}'
+"healthy"
+```
+
+Read-only root was also confirmed via `ReadonlyRootfs=true`; there is no shell in the runtime image to run `touch /etc/test` inside the container itself.
+
+Trivy scan:
+
+```text
+$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  aquasec/trivy:0.59.1 image --severity HIGH,CRITICAL --no-progress \
+  quicknotes:lab6
+
+quicknotes:lab6 (debian 12.14)
+Total: 0 (HIGH: 0, CRITICAL: 0)
+```
+
+Trivy also reported Go stdlib findings inside the compiled binaries; the distroless OS layer itself had zero HIGH/CRITICAL findings.
+
+The best security-per-line default here is `cap_drop: [ALL]`. It removes Linux capabilities from the container process namespace with one YAML line and directly reduces kernel-level escape options. Distroless and nonroot matter a lot too, but capability dropping is the clearest enforcement knob in Compose.


### PR DESCRIPTION
## Summary
- Add `flake.nix` + `flake.lock` building QuickNotes via `buildGoModule` and a deterministic `dockerTools` OCI image
- Prove identical store/image digests across two independent `nixos/nix` containers; contrast with divergent Lab 6 `docker build --no-cache` digests
- Add CI workflow `.github/workflows/nix-repro.yml` with two parallel build jobs and a digest compare gate

## Test plan
- [x] `nix build .#quicknotes` + `/health`
- [x] Two container hashes match for binary and OCI tarball
- [x] Lab 6 double `--no-cache` digests differ
- [x] CI green (equal digests) + red (deliberate break)