### PR TITLE
Lab 11: reproducible Nix flake - Go build + deterministic OCI image

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder ---------------------------------------------------------------
+FROM golang:1.24 AS builder
+WORKDIR /src
+
+# Copy the module manifest first so `go mod download` is cached independently
+# of the source — edits to .go files don't bust the dependency layer.
+COPY go.mod ./
+RUN go mod download
+
+# Now the source.
+COPY . .
+
+# Static, stripped, reproducible binary. CGO off so distroless-static (which has
+# no libc / dynamic linker) can run it.
+RUN CGO_ENABLED=0 GOOS=linux GOTOOLCHAIN=local \
+    go build -trimpath -ldflags='-s -w' -o /out/quicknotes .
+
+# A /data dir owned by the nonroot uid, so a fresh named volume mounted here
+# inherits writable ownership instead of root-owned.
+RUN mkdir -p /data && chown 65532:65532 /data
+
+# ---- runtime ---------------------------------------------------------------
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /out/quicknotes /quicknotes
+COPY --from=builder /src/seed.json /seed.json
+COPY --from=builder --chown=65532:65532 /data /data
+
+ENV ADDR=:8080 \
+    DATA_PATH=/data/notes.json \
+    SEED_PATH=/seed.json
+
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/quicknotes"]

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,3 +1,3 @@
 module quicknotes
 
-go 1.24
+go 1.23

--- a/app/main.go
+++ b/app/main.go
@@ -7,11 +7,19 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
 
 func main() {
+	// Self-healthcheck mode: the distroless runtime image has no shell or curl,
+	// so the container's HEALTHCHECK re-invokes this same binary (the only one in
+	// the image) to probe /health. Exit 0 = healthy, 1 = unhealthy.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		os.Exit(healthcheck())
+	}
+
 	addr := envOrDefault("ADDR", ":8080")
 	dataPath := envOrDefault("DATA_PATH", "data/notes.json")
 	seedPath := envOrDefault("SEED_PATH", "seed.json")
@@ -49,6 +57,24 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Printf("shutdown: %v", err)
 	}
+}
+
+func healthcheck() int {
+	addr := envOrDefault("ADDR", ":8080")
+	host := addr
+	if strings.HasPrefix(addr, ":") {
+		host = "127.0.0.1" + addr
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://" + host + "/health")
+	if err != nil {
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 1
+	}
+	return 0
 }
 
 func envOrDefault(k, def string) string {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: /data/notes.json
+      SEED_PATH: /seed.json
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+
+    # --- Hardening: the 6 security defaults (Lecture 6) ---
+    read_only: true            # 4. read-only root filesystem
+    tmpfs:
+      - /tmp                   #    ...with a writable tmpfs (the /data volume stays writable)
+    cap_drop:
+      - ALL                    # 3. drop every Linux capability (QuickNotes needs none)
+    security_opt:
+      - no-new-privileges:true # 5. block setuid privilege escalation
+    # (1) USER nonroot and (2) distroless base come from app/Dockerfile.
+    # (6) Trivy scan documented in submissions/lab6.md.
+
+    healthcheck:
+      # Distroless has no shell/curl — re-invoke the app binary's healthcheck mode.
+      test: ["CMD", "/quicknotes", "healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "QuickNotes — reproducible build with Nix (Lab 11)";
+
+  # Pinned to a channel branch; flake.lock freezes the exact revision so every
+  # clone resolves the identical nixpkgs — the load-bearing file for repro.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # Task 1 — the static Go binary, built from ./app.
+      quicknotes = pkgs.buildGoModule {
+        pname = "quicknotes";
+        version = "0.1.0";
+        src = ./app;
+        # QuickNotes has zero external dependencies (no go.sum) — nothing to
+        # vendor, so the vendor hash is null. See design question (b).
+        vendorHash = null;
+        CGO_ENABLED = 0; # static binary, no libc
+        ldflags = [ "-s" "-w" ]; # strip symbols + DWARF (size + repro)
+        # buildGoModule + Nix already give a deterministic, timestamp-free build.
+      };
+
+      # Task 2 — a deterministic OCI image, built with Nix (no Docker).
+      dockerImage = pkgs.dockerTools.buildImage {
+        name = "quicknotes";
+        tag = "nix";
+        # No `created` timestamp is set -> defaults to the Unix epoch, so the
+        # digest is stable across builds (see design question e).
+        copyToRoot = pkgs.buildEnv {
+          name = "image-root";
+          paths = [ quicknotes ];
+          pathsToLink = [ "/bin" ];
+        };
+        # A world-writable /tmp so the nonroot app can persist notes.json.
+        extraCommands = "mkdir -m 1777 tmp";
+        config = {
+          Entrypoint = [ "/bin/quicknotes" ];
+          ExposedPorts = { "8080/tcp" = { }; };
+          Env = [ "ADDR=:8080" "DATA_PATH=/tmp/notes.json" ];
+          User = "65534:65534"; # nobody — nonroot
+        };
+      };
+    in
+    {
+      packages.${system} = {
+        quicknotes = quicknotes;
+        default = quicknotes;
+        docker = dockerImage;
+      };
+
+      # `nix develop` drops collaborators into a shell with the Go toolchain.
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [ go gopls golangci-lint ];
+      };
+    };
+}

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,165 @@
+# Lab 11 — Reproducible Builds of QuickNotes with Nix
+
+Flake at the repo root: [`../flake.nix`](../flake.nix) (+ `flake.lock`, pinning the
+exact `nixos-24.11` nixpkgs revision). Built inside `nixos/nix` (Nix isn't native
+on Windows; the container is the lab's recommended path).
+
+---
+
+## Task 1 — Reproducible Go Build via Nix Flake
+
+### The flake
+
+`packages.quicknotes` builds `./app` with `pkgs.buildGoModule`:
+`vendorHash = null` (QuickNotes has zero external deps — nothing to vendor),
+`CGO_ENABLED = 0` (static), `ldflags = [ "-s" "-w" ]`. A `devShells.default`
+exposes `go`, `gopls`, `golangci-lint` for `nix develop`.
+
+### Reproducibility proof — two independent builds, identical store hash
+
+```text
+# build A
+$ nix build .#quicknotes
+$ nix-store --query --hash $(readlink result)
+sha256:1105i4ql5529h1bbbsabva6kzvc2rhq657vrjdzm868mrh41kd4d
+
+# build B — rebuilt from scratch and verified
+$ nix build --rebuild .#quicknotes    # exit 0 => output is bit-identical
+$ nix-store --query --hash $(readlink result)
+sha256:1105i4ql5529h1bbbsabva6kzvc2rhq657vrjdzm868mrh41kd4d   # identical to A
+```
+
+`nix build --rebuild` is Nix's native reproducibility check: it rebuilds the
+derivation and **fails with a hash mismatch if the output differs** — so a clean
+exit *is* the proof of a bit-identical rebuild.
+
+### It runs
+
+```text
+$ DATA_PATH=/tmp/notes.json ./result/bin/quicknotes &
+2026/07/12 12:48:52 quicknotes listening on :8080 (notes loaded: 0)
+$ ./result/bin/quicknotes healthcheck ; echo $?     # in-binary probe of /health
+0                                                    # exit 0 = serving OK
+```
+
+(The Nix-built binary is statically linked — `patchelf` reports "most likely
+statically linked", confirming `CGO_ENABLED=0`.)
+
+### 1.3 Design questions
+
+**a) Why doesn't `go build` produce bit-identical output on two machines?**
+Several leaks: (1) the **Go toolchain version** differs per machine → different
+codegen; (2) **absolute paths** get baked into the binary (GOROOT/GOPATH, the
+build directory) unless you pass `-trimpath`, so a different checkout dir yields a
+different binary; (3) **dependency resolution** can drift — without a committed
+`go.sum`/vendor dir, the module proxy may hand back different versions; (4) the
+embedded **build ID** derives from those inputs. Nix removes all of it: it pins
+the exact Go version (from nixpkgs), builds in a sandbox with fixed paths, and
+vendors dependencies deterministically — same inputs in, same bytes out.
+
+**b) `vendorHash` is a SHA over what? What if it's `null`?**
+It's a **fixed-output hash over the complete set of vendored dependencies** — the
+exact bytes of every module Go pulls for the build. Pinning it lets Nix fetch
+deps in a network-allowed fixed-output derivation and guarantees the same
+dependency tree every time. `vendorHash = null` tells `buildGoModule` the module
+has **no dependencies to vendor** and skips the vendor derivation entirely —
+correct for QuickNotes (no `go.sum`, zero deps). Set `null` on a module that
+*does* have deps and the build fails (it can't find the vendored packages).
+
+**c) Why is `flake.lock` the single most important file for reproducibility?**
+`inputs.nixpkgs.url = "…nixos-24.11"` is a **moving branch**; `flake.lock` freezes
+it to one exact git commit. Because the *entire* build environment — the Go
+compiler, stdenv, coreutils, every build flag — comes from that pinned nixpkgs,
+the lock is what makes "same inputs" literally true across clones and machines.
+**Delete it before the second build** and Nix re-resolves `nixos-24.11` to
+whatever the branch points at *now* (a newer commit) → a different Go/stdenv →
+a potentially different output hash. No lock, no reproducibility.
+
+**d) `buildGoModule` vs `buildGoApplication` — which for QuickNotes?**
+`buildGoModule` (in nixpkgs) uses Go modules and vendors all deps through one
+fixed-output derivation keyed by `vendorHash` — self-contained, no extra tooling.
+`buildGoApplication` (from `gomod2nix`) instead turns `go.mod`/`go.sum` into a Nix
+expression with **one derivation per dependency** (finer caching, no single
+vendorHash) but needs the `gomod2nix` tool and a generated file. For QuickNotes —
+**`buildGoModule`**: with zero dependencies there's nothing to vendor and no
+`vendorHash` to maintain (`null`), so the per-dependency granularity of
+`buildGoApplication` buys nothing. Simplest correct choice.
+
+---
+
+## Task 2 — Deterministic OCI Image
+
+### The flake output
+
+`packages.docker` uses `pkgs.dockerTools.buildImage` (no Docker needed) to pack
+the Task 1 binary: `Entrypoint = [ "/bin/quicknotes" ]`, `ExposedPorts 8080/tcp`,
+`User = "65534:65534"` (nonroot), `Env` sets `DATA_PATH=/tmp/notes.json` and a
+world-writable `/tmp` so the nonroot app can persist. No `created` timestamp is
+set, so it defaults to the Unix epoch → a stable digest.
+
+### Reproducibility proof — identical SHA-256 across two builds
+
+```text
+$ nix build .#docker ; sha256sum result
+3a16430ecc46f6d9fac8b858e8ea10bbb2f3967d33fd631779442ad35d9ec11c
+$ nix build --rebuild .#docker ; sha256sum result
+3a16430ecc46f6d9fac8b858e8ea10bbb2f3967d33fd631779442ad35d9ec11c   # identical
+
+# loadable + runs, nonroot, correct config:
+$ docker load < result ; docker run -p 8097:8080 quicknotes:nix ; curl :8097/health
+{"notes":0,"status":"ok"}   # 200
+$ docker inspect quicknotes:nix --format '{{.Config.User}} {{json .Config.ExposedPorts}} {{json .Config.Entrypoint}}'
+65534:65534 {"8080/tcp":{}} ["/bin/quicknotes"]
+```
+
+### Contrast — Lab 6's `docker build` is NOT reproducible
+
+```text
+$ docker build --no-cache -t qn-lab6:run1 ./app
+$ docker build --no-cache -t qn-lab6:run2 ./app
+$ docker images --no-trunc qn-lab6 --format '{{.Tag}} {{.ID}}'
+run1 sha256:60cb2a84bea1a47eea144ed0560e98107dba770caee175da489846cd0b8134c5
+run2 sha256:47bdf5144556c042e63e38e3180896ad940d9714d22e965608278a75a230ccbb   # ≠ run1
+```
+
+Two `--no-cache` builds of the *same* Dockerfile + source → **different image
+IDs** (layer/config timestamps), while two Nix builds are byte-identical.
+
+Image size: Nix-built **8.44 MB** vs Lab 6 distroless **8.56 MB** — essentially the
+same (both are just the static binary), but only the Nix one is bit-reproducible.
+
+### 2.4 Design questions
+
+**e) What does `docker build` do that introduces non-determinism?**
+Plenty, even from the same Dockerfile + Git SHA: it stamps each layer and the
+image config with **build timestamps** (`created`); `RUN` steps execute in a live
+environment where `apt`/`go`/network fetch **whatever is current** (unpinned
+package versions, moving mirrors); file **mtimes** and ordering land in the tar
+layers; and base images referenced by tag can move. `dockerTools.buildImage`
+sidesteps all of it — it assembles the layer tar from Nix store paths with
+normalized timestamps (epoch) and no `RUN`, so the bytes are a pure function of
+the inputs.
+
+**f) What can a reproducible image prove that a signed-but-non-reproducible one can't?**
+A signature proves **who** built/published the image and that it wasn't altered
+*after* signing — but you must **trust the builder** that the bytes match the
+source. A reproducible image proves **the bytes correspond to this exact source**:
+anyone can rebuild from the pinned inputs and get the identical digest, so an
+auditor can independently verify "this artifact is what the source compiles to"
+without trusting the build machine. Signing answers *provenance*; reproducibility
+answers *"does the binary actually match the audited source?"* — it closes the
+gap where a compromised build server signs a backdoored image.
+
+**g) The trade-off — why is `docker build` still most teams' default?**
+Nix's cost is a **steep learning curve** and ecosystem friction: you write Nix,
+pin `vendorHash`, manage the store, and many tools/registries assume a Dockerfile.
+`docker build` is universally understood, works with every base image and CI, and
+"good enough" for teams whose threat model doesn't demand bit-for-bit
+verifiability. Reproducibility is a real cost you pay up front for a guarantee
+most teams don't (yet) require — so Dockerfiles win on ergonomics and ubiquity.
+
+---
+
+## Bonus — CI-Verified Reproducibility
+
+Not attempted (Task 1 + Task 2 completed).

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,198 @@
+# Lab 6 — Containers: Dockerize QuickNotes
+
+Host: Windows 11 + Docker **29.1.2**. Files:
+[`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
+
+---
+
+## Task 1 — Multi-Stage Dockerfile, ≤ 25 MB
+
+### What the Dockerfile does
+
+Two stages: a `golang:1.24` **builder** that compiles a static, stripped binary,
+and a `gcr.io/distroless/static:nonroot` **runtime** that carries only the binary,
+`seed.json`, and a nonroot-owned `/data`.
+
+| Requirement | How |
+|-------------|-----|
+| Multi-stage | `builder` + `runtime` |
+| Builder pinned | `golang:1.24` |
+| Runtime base | `gcr.io/distroless/static:nonroot` (no shell, no apt) |
+| Static binary | `CGO_ENABLED=0` |
+| Stripped / reproducible | `-ldflags='-s -w' -trimpath` |
+| Nonroot | `USER nonroot:nonroot` (uid 65532) |
+| Exec entrypoint + EXPOSE | `ENTRYPOINT ["/quicknotes"]`, `EXPOSE 8080` |
+| Cache-friendly order | `COPY go.mod` + `go mod download` **before** `COPY . .` |
+
+### Build + verify (real output)
+
+```text
+$ docker images quicknotes:lab6 --format '{{.Repository}}:{{.Tag}}  {{.Size}}'
+quicknotes:lab6  8.56MB                       # ≤ 25 MB ✅
+
+$ docker inspect quicknotes:lab6 --format '{{.Config.User}} | {{json .Config.ExposedPorts}} | {{json .Config.Entrypoint}}'
+nonroot:nonroot | {"8080/tcp":{}} | ["/quicknotes"]
+
+$ docker run -d -p 8080:8080 quicknotes:lab6 ; curl -s :8080/health
+{"notes":4,"status":"ok"}                     # 200
+# POST /notes -> 201, GET /notes shows the new note
+```
+
+Base-image comparison: builder `golang:1.24` is **894 MB**, the distroless runtime
+base is **2.21 MB**, and our final image is **8.56 MB** (binary + seed + /data).
+Multi-stage threw away ~890 MB of toolchain.
+
+### 1.2 Design questions
+
+**a) Why does layer order matter? (`COPY . .` early vs `go.mod` first)**
+
+Each Dockerfile instruction is a cached layer keyed on its inputs. With
+`COPY . . && go mod download && go build`, *any* source edit changes the `COPY . .`
+layer, which invalidates everything after it — so `go mod download` re-runs on
+every rebuild. With `COPY go.mod ./ && go mod download && COPY . . && go build`,
+the download layer is keyed only on `go.mod`/`go.sum`; a source-only edit reuses
+the cached dependencies and only re-runs the build. On a rebuild after touching a
+`.go` file, strategy A pays the dependency download again (cache miss), strategy B
+skips it (cache hit). *Caveat for this repo:* QuickNotes has zero external
+dependencies, so `go mod download` is near-instant and the absolute saving here is
+small — but the ordering is still correct and on a real dependency tree it's the
+difference between a sub-second rebuild and re-pulling hundreds of modules.
+
+**b) Why `CGO_ENABLED=0`?**
+
+It forces a fully static binary with no libc / dynamic-linker dependency. The
+default `CGO_ENABLED=1` links against the host's glibc dynamically. `distroless/
+static` deliberately contains **no libc and no dynamic linker (ld.so)**, so a
+dynamically-linked binary fails to start — the kernel can't find the ELF
+interpreter and you get `no such file or directory` (on the binary that visibly
+exists). Forgetting the flag = a container that won't run.
+
+**c) What is `gcr.io/distroless/static:nonroot`?**
+
+A minimal runtime image containing essentially only: CA certificates, `/etc/passwd`
+with a `nonroot` user (uid 65532), timezone data, and a `/tmp` dir. What it
+*doesn't* have is the point — **no shell, no package manager, no busybox, no
+libc, no coreutils**. That shrinks the attack surface and, crucially, the CVE
+surface: there are no OS packages to be vulnerable. Trivy confirms **0 HIGH/
+CRITICAL in the OS layer** (see Bonus).
+
+**d) `-ldflags='-s -w'` and `-trimpath`?**
+
+`-s` drops the symbol table, `-w` drops DWARF debug info — together they shrink
+the binary and remove most of what a debugger/symbolizer would use. `-trimpath`
+strips absolute build-machine file paths from the binary, replacing them with
+module-relative paths. The cost: `-s -w` makes post-mortem debugging and
+profiling with symbols much harder (no `delve`, degraded stack symbolization);
+`-trimpath` removes local path info that some debug workflows rely on. The payoff
+is a smaller, **reproducible** binary that doesn't leak the build host's directory
+layout — the right trade for a shipped image.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+### Persistence test (real output)
+
+```text
+$ docker compose up --build -d ; docker compose ps --format '{{.Health}}'
+healthy
+
+$ curl -XPOST -d '{"title":"durable","body":"survive a restart"}' :8080/notes      # 201
+present after create:        1
+
+$ docker compose down ; docker compose up -d
+present after down + up:     1     # ✅ survived (named volume kept)
+
+$ docker compose down -v ; docker compose up -d
+present after down -v + up:  0     # gone (volume destroyed)
+```
+
+### 2.2 Design questions
+
+**e) Distroless has no shell — how do you healthcheck it?**
+
+I made the QuickNotes binary **dual-mode**: `quicknotes healthcheck` does an
+in-process HTTP GET to `/health` and exits `0` (healthy) or `1` (unhealthy). The
+Compose healthcheck re-invokes the only binary in the image in exec form:
+`test: ["CMD", "/quicknotes", "healthcheck"]`. No shell, no `wget`, no sidecar.
+This is the lab's "use a binary that's already in the image" option, and it's the
+cleanest — verified: `docker compose ps` reports **healthy**.
+
+**f) Why does the named volume survive `docker compose down`? What destroys it?**
+
+`docker compose down` removes containers and the default network, but **named
+volumes are separate objects with their own lifecycle** — they are intentionally
+left intact so data outlives container churn, and re-attach on the next `up`.
+What destroys it: `docker compose down -v` (or `docker volume rm
+quicknotes-data`). The test above shows exactly this: the note survives `down +
+up` and disappears only after `down -v`.
+
+**g) `depends_on` without `condition: service_healthy`?**
+
+Plain `depends_on: [x]` only waits for container `x` to be **started** (its
+process launched / created), *not* for it to be **ready** to serve. The bug:
+the dependent service can come up and start making requests before `x` is
+actually accepting connections — e.g. an app querying a database that has
+"started" but isn't listening yet, giving intermittent connection-refused races
+on boot. `condition: service_healthy` makes Compose wait for `x`'s healthcheck to
+pass first.
+
+---
+
+## Bonus — The 6 Security Defaults
+
+### Hardened `services.quicknotes` block
+
+```yaml
+read_only: true            # 4. read-only root filesystem
+tmpfs:
+  - /tmp                   #    writable scratch (the /data named volume stays writable)
+cap_drop:
+  - ALL                    # 3. drop every Linux capability (QuickNotes needs none)
+security_opt:
+  - no-new-privileges:true # 5. block setuid privilege escalation
+# 1. USER nonroot  + 2. distroless base  come from app/Dockerfile
+# 6. Trivy scan below
+```
+
+### Verification (real output)
+
+| # | Default | Command | Result |
+|---|---------|---------|--------|
+| 1 | `USER nonroot` | `inspect ... .Config.User` | `nonroot:nonroot` |
+| 2 | No shell | `compose exec quicknotes sh` | `exec: "sh": executable file not found` (fails ✅) |
+| 3 | Caps dropped | `inspect ... .HostConfig.CapDrop` | `[ALL]` |
+| 4 | Read-only root | `inspect ... .HostConfig.ReadonlyRootfs` | `true` |
+| 5 | no-new-privileges | `inspect ... .HostConfig.SecurityOpt` | `[no-new-privileges:true]` |
+
+All five enforced while the service still reports **healthy** and serves
+`/health` — read-only root + dropped caps don't break QuickNotes because it only
+writes to the `/data` volume (and `/tmp` tmpfs).
+
+### Trivy scan
+
+```text
+$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+    aquasec/trivy:0.59.1 image --severity HIGH,CRITICAL --no-progress quicknotes:lab6
+
+quicknotes:lab6 (debian 13.5)      Total: 0  (HIGH: 0, CRITICAL: 0)   # OS layer — clean
+quicknotes (gobinary)              Total: 12 (HIGH: 12, CRITICAL: 0)  # all Go stdlib
+```
+
+The **OS layer has zero HIGH/CRITICAL** — exactly the distroless payoff (no OS
+packages = nothing to patch). The 12 HIGH are all in the **Go standard library**
+compiled into the binary (e.g. `net/url`, `net/mail`, `net/http/httputil`),
+fixed in Go `1.25.8 / 1.26.1`. The lab pins the builder to Go `1.24` (whose
+latest patch `1.24.13` still predates those fixes), so they remain; in a real
+pipeline you'd bump the builder's Go minor version to clear them. Distroless
+fixed the base image; the binary's stdlib is a separate supply-chain axis.
+
+### Most security per line of YAML
+
+**`cap_drop: [ALL]`** — one line strips every Linux capability the container
+would otherwise inherit (~14 by default, including `CAP_NET_RAW`,
+`CAP_CHOWN`, `CAP_SETUID`…), collapsing a huge slice of the kernel attack surface
+that container escapes typically abuse. QuickNotes needs none, so the cost is
+zero. Runner-up is `read_only: true`, which neutralizes persistence/tampering on
+the root filesystem in one line — but `cap_drop: ALL` removes the most latent
+privilege for the least YAML.


### PR DESCRIPTION
## Goal
Build QuickNotes reproducibly with a Nix flake, and prove two independent builds produce identical hashes — for the binary and for a deterministic OCI image.

## Changes
- flake.nix (repo root): nixpkgs pinned via flake.lock; `packages.quicknotes` builds ./app with buildGoModule (CGO_ENABLED=0, ldflags -s -w, vendorHash=null — QuickNotes has zero external deps); `packages.docker` builds a deterministic OCI image with dockerTools.buildImage (exec Entrypoint, EXPOSE 8080/tcp, nonroot 65534, no Docker involved); `devShells.default` with go/gopls/golangci-lint.
- flake.lock: pins nixpkgs to rev 50ab793786d9de88ee30ec4e4c24fb4236fc2674 (nixos-24.11).
- app/go.mod: minimum Go set to 1.23 to match the toolchain the pinned nixpkgs provides (the app uses no 1.24-only features).
- submissions/lab11.md: flake walkthrough, both reproducibility proofs, the Lab 6 contrast, design answers a–g.

## Testing
- Binary: `nix build .#quicknotes` -> store hash sha256:1105i4ql5529h1bbbsabva6kzvc2rhq657vrjdzm868mrh41kd4d; `nix build --rebuild` rebuilds from scratch and yields the identical hash (exit 0 = bit-identical). The static binary runs and serves /health.
- Image: `nix build .#docker` -> sha256 3a16430ecc46f6d9fac8b858e8ea10bbb2f3967d33fd631779442ad35d9ec11c; rebuild gives the identical digest. It loads via `docker load`, runs as nonroot (65534), and serves /health 200.
- Contrast: two `docker build --no-cache` runs of the Lab 6 Dockerfile give different image IDs (60cb2a84… vs 47bdf514…), i.e. not reproducible.

## Checklist
- [x] Title is a clear sentence (≤ 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/lab11.md` updated
