### PR TITLE
Lab 12: Moscow-time endpoint as a WebAssembly component (Spin + TinyGo)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ Thumbs.db
 # Local agent config (not part of the course)
 .claude/
 
+# Lab 12 — WebAssembly build artifacts (reproduced by `spin build` / `tinygo build`)
+*.wasm
+.spin/
+
 # NOTE: deliberately NOT ignored, because students commit them as lab evidence:
 #   submissions/labN.md        (lab reports)
 #   .github/workflows/*.yml    (Lab 3 CI)

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder ---------------------------------------------------------------
+FROM golang:1.24 AS builder
+WORKDIR /src
+
+# Copy the module manifest first so `go mod download` is cached independently
+# of the source — edits to .go files don't bust the dependency layer.
+COPY go.mod ./
+RUN go mod download
+
+# Now the source.
+COPY . .
+
+# Static, stripped, reproducible binary. CGO off so distroless-static (which has
+# no libc / dynamic linker) can run it.
+RUN CGO_ENABLED=0 GOOS=linux GOTOOLCHAIN=local \
+    go build -trimpath -ldflags='-s -w' -o /out/quicknotes .
+
+# A /data dir owned by the nonroot uid, so a fresh named volume mounted here
+# inherits writable ownership instead of root-owned.
+RUN mkdir -p /data && chown 65532:65532 /data
+
+# ---- runtime ---------------------------------------------------------------
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=builder /out/quicknotes /quicknotes
+COPY --from=builder /src/seed.json /seed.json
+COPY --from=builder --chown=65532:65532 /data /data
+
+ENV ADDR=:8080 \
+    DATA_PATH=/data/notes.json \
+    SEED_PATH=/seed.json
+
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/quicknotes"]

--- a/app/main.go
+++ b/app/main.go
@@ -7,11 +7,19 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 )
 
 func main() {
+	// Self-healthcheck mode: the distroless runtime image has no shell or curl,
+	// so the container's HEALTHCHECK re-invokes this same binary (the only one in
+	// the image) to probe /health. Exit 0 = healthy, 1 = unhealthy.
+	if len(os.Args) > 1 && os.Args[1] == "healthcheck" {
+		os.Exit(healthcheck())
+	}
+
 	addr := envOrDefault("ADDR", ":8080")
 	dataPath := envOrDefault("DATA_PATH", "data/notes.json")
 	seedPath := envOrDefault("SEED_PATH", "seed.json")
@@ -49,6 +57,24 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Printf("shutdown: %v", err)
 	}
+}
+
+func healthcheck() int {
+	addr := envOrDefault("ADDR", ":8080")
+	host := addr
+	if strings.HasPrefix(addr, ":") {
+		host = "127.0.0.1" + addr
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://" + host + "/health")
+	if err != nil {
+		return 1
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 1
+	}
+	return 0
 }
 
 func envOrDefault(k, def string) string {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  quicknotes:
+    build:
+      context: ./app
+    image: quicknotes:lab6
+    ports:
+      - "8080:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: /data/notes.json
+      SEED_PATH: /seed.json
+    volumes:
+      - quicknotes-data:/data
+    restart: unless-stopped
+
+    # --- Hardening: the 6 security defaults (Lecture 6) ---
+    read_only: true            # 4. read-only root filesystem
+    tmpfs:
+      - /tmp                   #    ...with a writable tmpfs (the /data volume stays writable)
+    cap_drop:
+      - ALL                    # 3. drop every Linux capability (QuickNotes needs none)
+    security_opt:
+      - no-new-privileges:true # 5. block setuid privilege escalation
+    # (1) USER nonroot and (2) distroless base come from app/Dockerfile.
+    # (6) Trivy scan documented in submissions/lab6.md.
+
+    healthcheck:
+      # Distroless has no shell/curl — re-invoke the app binary's healthcheck mode.
+      test: ["CMD", "/quicknotes", "healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  quicknotes-data:

--- a/submissions/lab12.md
+++ b/submissions/lab12.md
@@ -1,0 +1,247 @@
+# Lab 12 — WebAssembly Containers: a QuickNotes Endpoint on Spin
+
+**Test rig:** Windows 11 host → WSL2 (Ubuntu) for Spin/TinyGo/wasmtime; Docker
+Desktop for the Lab 6 container.
+**Pinned tooling:** Spin **3.4.0**, TinyGo **0.41.1** (using Go 1.24.4, LLVM 20.1.1),
+wasmtime **46.0.1**, hyperfine **1.18.0**, SDK `github.com/spinframework/spin-go-sdk/v2 v2.2.1`.
+
+> **A note on tooling churn (the lab warned about exactly this).** I first
+> installed the latest Spin (**4.0.2**). Its `http-go` template has *already moved
+> off TinyGo*: it scaffolds SDK **v3** and builds with `go tool componentize-go
+> build` — and that template is broken out of the box (`Error: failed to read path
+> for WIT [wit]` — it expects a `wit/` directory the scaffold never creates, and
+> `componentize-go` has no `--wit` flag). I therefore pinned **Spin 3.4.0**, the
+> version this lab was validated against, whose template produces exactly the
+> TinyGo build the spec describes.
+
+---
+
+## Task 1 — A WASM Endpoint with the Spin SDK
+
+Scaffolded with `spin new -t http-go moscow-time --accept-defaults`.
+
+### `spin.toml` ([`../wasm/moscow-time/spin.toml`](../wasm/moscow-time/spin.toml))
+
+```toml
+[[trigger.http]]
+route = "/time"
+component = "moscow-time"
+
+[component.moscow-time]
+source = "main.wasm"
+allowed_outbound_hosts = []          # least privilege: no outbound network at all
+[component.moscow-time.build]
+command = "tinygo build -target=wasip1 -buildmode=c-shared -no-debug -o main.wasm ."
+```
+
+### `main.go` ([`../wasm/moscow-time/main.go`](../wasm/moscow-time/main.go))
+
+Registers the handler via `spinhttp.Handle` (SDK v2). Moscow time comes from
+`time.FixedZone("MSK", 3*60*60)` — **not** `time.LoadLocation`, because TinyGo
+embeds no tzdata. The response is a concrete struct (not `map[string]any`) to stay
+inside TinyGo's reflection limits.
+
+### Build + run
+
+```text
+$ spin build
+Building component moscow-time with `tinygo build -target=wasip1 -buildmode=c-shared -no-debug -o main.wasm .`
+Finished building all Spin components
+
+$ ls -l main.wasm
+515910 bytes  (~504 KB)
+
+$ spin up --listen 127.0.0.1:3000
+Serving http://127.0.0.1:3000
+
+$ curl -s http://127.0.0.1:3000/time
+{"unix":1784066567,"iso":"2026-07-15T01:02:47+03:00","hour_minute":"01:02",
+ "moscow":"2026-07-15 01:02:47","zone":"Europe/Moscow (UTC+3)"}
+# HTTP/1.1 200 OK ; content-type: application/json
+```
+
+### 1.4 Design questions
+
+**a) Browser WASM (`js/wasm`) vs server WASM (`wasip1`) — what's missing, what do you gain?**
+`GOOS=js GOARCH=wasm` targets a **browser**: the module can't do anything on its
+own — it needs the `wasm_exec.js` glue and reaches the world only through
+JavaScript (`syscall/js`, the DOM, `fetch`). `tinygo build -target=wasip1` targets
+a **WASI host**: what's *missing* is the entire JS/DOM bridge (no `syscall/js`, no
+DOM, no JS `fetch`). What you *gain* is a host-agnostic module that runs outside a
+browser on any WASI runtime, with POSIX-ish capabilities — clocks, env vars,
+preopened files, and (via wasi-http) sockets — **granted explicitly by the host**.
+It's also far smaller and starts far faster, because there's no JS engine in the
+loop.
+
+**b) Why does the build need `-buildmode=c-shared`?**
+Spin's host doesn't want a program to *run*; it wants a module that **exports a
+handler it can call per HTTP request**. `-buildmode=c-shared` makes TinyGo emit a
+shared-library-shaped module that **exports** the SDK's HTTP handler symbol,
+instead of a WASI *command* module whose only entrypoint is `_start`. Drop the
+flag and you get a command module with no exported handler: `spin up` loads it,
+can't find the export, and answers **HTTP 500 with empty component logs**. Our
+Bonus experiment shows the mirror image: the c-shared component under bare
+`wasmtime run` **exits 0 and prints nothing**, because `_start` (our deliberately
+empty `main()`) is the only thing bare wasmtime knows how to call.
+
+**c) `allowed_outbound_hosts = []` — capability security vs Docker's `--network none`.**
+WASM/WASI is **capability-based**: a module begins with **zero ambient authority**
+— no filesystem, no sockets, no env — and the host hands it each capability
+explicitly. `allowed_outbound_hosts = []` grants *no* outbound-network capability,
+so the module literally **cannot construct a socket**: the function to do so was
+never imported into it. Docker's `--network none` is a **namespace** restriction:
+the process is still a full OS binary that *can* call `socket()`; the kernel just
+gives it an empty network namespace. The syscall surface remains, so a kernel bug
+or a namespace misconfiguration can still leak. WASM denies by **absence of the
+ability** (the module's import list *is* the sandbox); Docker denies by
+**configuration on a shared kernel**.
+
+**d) Which TinyGo stdlib gaps did you hit?**
+Two, exactly as the pitfalls predicted:
+1. **No tzdata.** `time.LoadLocation("Europe/Moscow")` cannot work — TinyGo embeds
+   no timezone database. Fixed by `time.FixedZone("MSK", 3*60*60)` (Moscow has been
+   a fixed UTC+3 with no DST since 2014).
+2. **Limited reflection.** `encoding/json` over `map[string]any` is a known rough
+   edge, so the response is a **concrete struct with json tags**, which marshals
+   cleanly. More broadly TinyGo is a *subset*: heavy reflection, parts of `net`,
+   `os/exec`, and full scheduler semantics are where it diverges from upstream Go.
+
+---
+
+## Task 2 — Perf Comparison vs the Lab 6 Container
+
+Both served locally; `hyperfine --warmup 5 --runs 50`; cold start = 5 samples each
+(kill → restart → time to first 200).
+
+| Dimension              | Lab 6 Docker | Lab 12 WASM/Spin |
+|------------------------|-------------:|-----------------:|
+| Artifact size          |  **8.61 MB** | **0.49 MB** (515,910 B) |
+| Cold start (p50)       |   **480 ms** |        **83 ms** |
+| Warm latency p50       |  **6.53 ms** |      **8.54 ms** |
+| Warm latency p95       |      7.77 ms |          9.71 ms |
+
+Raw cold-start samples — Docker: 496 / 499 / 473 / 465 / 480 ms · Spin: 142 / 88 /
+62 / 64 / 83 ms.
+
+**WASM is ~17× smaller and cold-starts ~6× faster — but the container is ~25%
+faster once warm.** That inversion is the honest headline: a natively compiled Go
+binary beats a sandboxed WASM module on steady-state per-request work, while WASM
+wins decisively on start-up cost and footprint.
+
+*Measurement caveat:* hyperfine times the whole `curl` invocation, so ~4–5 ms of
+process spawn is included in **both** columns; and the Docker request crosses
+Docker Desktop's WSL port-forward while Spin is native in WSL. The size and
+cold-start figures are unaffected by this.
+
+### 2.3 Design questions
+
+**e) What dominates each platform's cold start?**
+- **Docker (480 ms):** almost none of it is the app. It's container plumbing —
+  creating namespaces and cgroups, assembling the (already-local) image layers,
+  starting the init process — and only then the Go runtime booting and binding a
+  listener.
+- **Spin/WASM (83 ms):** starting the `spin` host process, initializing the
+  wasmtime engine, loading + compiling the ~504 KB module, instantiating it, and
+  binding the listener. There is **no OS-level namespace or filesystem setup at
+  all** — the isolation boundary is the module's import list, not the kernel — so
+  there's simply far less to build.
+- Bare `wasmtime run` (19 ms per invocation, from the Bonus) isolates the pure
+  WASM part: engine + module instantiation with no server layer.
+
+**f) Where is WASM clearly better, and where is Docker still right?**
+**WASM wins** for short-lived, bursty, event-driven work — serverless/edge
+functions, per-request handlers, scale-to-zero. A 6× faster cold start and a 17×
+smaller artifact make cold scale-out and dense packing cheap (thousands of modules
+per host). It's also the right answer for **untrusted multi-tenant plugin code**,
+thanks to the capability sandbox. **Docker is still right** for long-running
+services that need a real OS surface: native libraries/CGO, arbitrary syscalls, a
+filesystem, exec'ing other processes, and the whole mature ecosystem (databases,
+sidecars, existing images). And — per our own numbers — for a steady
+high-throughput service, the native container is simply **faster per request**;
+there the WASM sandbox is overhead, not savings.
+
+**g) Multi-tenant safety — what concrete attack does WASM make harder?**
+**Container escape through the kernel syscall surface.** Containers share one
+kernel: a hostile tenant can probe 300+ syscalls, and a single kernel/runtime bug
+(the runc CVEs, dirty-COW-class flaws, a sloppy namespace or cgroup config) breaks
+them out onto the host and into other tenants. A WASM module **has no syscalls at
+all** — it can only call the functions the host explicitly imported. There is no
+`ptrace`, no `/proc`, no raw socket, no filesystem unless a directory was
+preopened. Even a *fully compromised* module is confined to its granted
+capabilities, so kernel-level escape isn't merely blocked — it's structurally
+unavailable. The attack surface shrinks from "the entire Linux ABI" to "the host's
+small, auditable import list."
+
+---
+
+## Bonus — Two WASM Execution Models
+
+Same Moscow-time logic, rebuilt as a **standalone WASI CLI module** (no Spin SDK):
+request arrives in env vars, response goes to stdout, module exits — the
+CGI-over-WASM shape. Source: [`../wasm-cli/main.go`](../wasm-cli/main.go).
+
+```text
+$ tinygo build -o main.wasm -target=wasi -no-debug ./main.go
+$ ls -l main.wasm
+379154 bytes  (~370 KB)
+
+$ wasmtime run --env REQUEST_METHOD=GET --env PATH_INFO=/time main.wasm
+Content-Type: application/json
+
+{"unix":1784066828,"iso":"2026-07-15T01:07:08+03:00","hour_minute":"01:07",
+ "moscow":"2026-07-15 01:07:08","zone":"Europe/Moscow (UTC+3)"}
+```
+
+And the Task 1 component under bare wasmtime:
+
+```text
+$ wasmtime run wasm/moscow-time/main.wasm
+exit=0            # ...and no output whatsoever
+```
+
+### Comparison of the two models
+
+| | Spin component (wasi-http) | WASI CLI module (`wasmtime run`) |
+|--|---------------------------:|---------------------------------:|
+| Module size            | 515,910 B (504 KB) | **379,154 B (370 KB)** |
+| Execution model        | persistent wasi-http server | one process per invocation |
+| Per-request cost       | **8.5 ms** (warm, pooled instance) | **19 ms** (full instantiate every call) |
+| Cold start             | 83 ms (once, then amortized) | 19 ms — but paid *every* invocation |
+| Runs under bare `wasmtime run`? | **No** (exits 0, no output) | Yes |
+
+The CLI module is smaller because it carries none of the wasi-http/SDK machinery.
+But it pays a full engine + module instantiation (~19 ms) on **every** request,
+whereas Spin instantiates once and pools — which is exactly why a warm Spin request
+(8.5 ms) beats a fresh `wasmtime run` (19 ms).
+
+### B.3 Design questions
+
+**h) Why can't the Task 1 Spin component run under bare `wasmtime run`?**
+Because it is **not a CLI program**. Built with `-buildmode=c-shared`, it *exports*
+a wasi-http handler for a host to invoke per request; its `main()` is deliberately
+empty. Bare `wasmtime run` only knows how to call the WASI **command** entrypoint
+`_start` — so it loads the module, runs the empty `main`, and **exits 0 having
+printed nothing** (exactly what we measured). Nothing is served because bare
+wasmtime never speaks wasi-http to the module. To host it you need a wasi-http
+host: Spin, or `wasmtime serve`.
+
+**i) Spin embeds wasmtime — so what does Spin *add*?**
+The whole application layer around the engine: **a wasi-http server loop** (accept
+TCP, translate HTTP into the component's wasi-http interface and the response
+back); **instance pooling / pre-instantiation**, so a request doesn't pay a full
+module instantiate each time — measurably, warm Spin 8.5 ms vs fresh
+`wasmtime run` 19 ms; **the manifest + routing layer** (`spin.toml` → routes →
+components); **capability and outbound-host policy** (`allowed_outbound_hosts`,
+key-value/SQLite stores); and the developer tooling (`spin new`, `spin build`,
+`spin up`).
+
+**j) When does each execution model fit?**
+- **Per-invocation `wasmtime run` (CGI-shaped):** batch and one-shot work — a
+  nightly report generator, a git hook, a sandboxed plugin invoked occasionally, a
+  one-off data transform. Every run is fully isolated, no state survives, and there
+  is no server to operate. The cost — ~19 ms of instantiation *per call* — makes it
+  the wrong shape for a high request rate.
+- **Spin's persistent wasi-http server:** an HTTP API or edge function under
+  continuous traffic — precisely our `/time` endpoint. The host stays up, modules
+  are pre-instantiated and pooled, so per-request cost drops to ~8.5 ms and a steady
+  stream is absorbed cheaply. The cost is running a server process.

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,198 @@
+# Lab 6 — Containers: Dockerize QuickNotes
+
+Host: Windows 11 + Docker **29.1.2**. Files:
+[`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
+
+---
+
+## Task 1 — Multi-Stage Dockerfile, ≤ 25 MB
+
+### What the Dockerfile does
+
+Two stages: a `golang:1.24` **builder** that compiles a static, stripped binary,
+and a `gcr.io/distroless/static:nonroot` **runtime** that carries only the binary,
+`seed.json`, and a nonroot-owned `/data`.
+
+| Requirement | How |
+|-------------|-----|
+| Multi-stage | `builder` + `runtime` |
+| Builder pinned | `golang:1.24` |
+| Runtime base | `gcr.io/distroless/static:nonroot` (no shell, no apt) |
+| Static binary | `CGO_ENABLED=0` |
+| Stripped / reproducible | `-ldflags='-s -w' -trimpath` |
+| Nonroot | `USER nonroot:nonroot` (uid 65532) |
+| Exec entrypoint + EXPOSE | `ENTRYPOINT ["/quicknotes"]`, `EXPOSE 8080` |
+| Cache-friendly order | `COPY go.mod` + `go mod download` **before** `COPY . .` |
+
+### Build + verify (real output)
+
+```text
+$ docker images quicknotes:lab6 --format '{{.Repository}}:{{.Tag}}  {{.Size}}'
+quicknotes:lab6  8.56MB                       # ≤ 25 MB ✅
+
+$ docker inspect quicknotes:lab6 --format '{{.Config.User}} | {{json .Config.ExposedPorts}} | {{json .Config.Entrypoint}}'
+nonroot:nonroot | {"8080/tcp":{}} | ["/quicknotes"]
+
+$ docker run -d -p 8080:8080 quicknotes:lab6 ; curl -s :8080/health
+{"notes":4,"status":"ok"}                     # 200
+# POST /notes -> 201, GET /notes shows the new note
+```
+
+Base-image comparison: builder `golang:1.24` is **894 MB**, the distroless runtime
+base is **2.21 MB**, and our final image is **8.56 MB** (binary + seed + /data).
+Multi-stage threw away ~890 MB of toolchain.
+
+### 1.2 Design questions
+
+**a) Why does layer order matter? (`COPY . .` early vs `go.mod` first)**
+
+Each Dockerfile instruction is a cached layer keyed on its inputs. With
+`COPY . . && go mod download && go build`, *any* source edit changes the `COPY . .`
+layer, which invalidates everything after it — so `go mod download` re-runs on
+every rebuild. With `COPY go.mod ./ && go mod download && COPY . . && go build`,
+the download layer is keyed only on `go.mod`/`go.sum`; a source-only edit reuses
+the cached dependencies and only re-runs the build. On a rebuild after touching a
+`.go` file, strategy A pays the dependency download again (cache miss), strategy B
+skips it (cache hit). *Caveat for this repo:* QuickNotes has zero external
+dependencies, so `go mod download` is near-instant and the absolute saving here is
+small — but the ordering is still correct and on a real dependency tree it's the
+difference between a sub-second rebuild and re-pulling hundreds of modules.
+
+**b) Why `CGO_ENABLED=0`?**
+
+It forces a fully static binary with no libc / dynamic-linker dependency. The
+default `CGO_ENABLED=1` links against the host's glibc dynamically. `distroless/
+static` deliberately contains **no libc and no dynamic linker (ld.so)**, so a
+dynamically-linked binary fails to start — the kernel can't find the ELF
+interpreter and you get `no such file or directory` (on the binary that visibly
+exists). Forgetting the flag = a container that won't run.
+
+**c) What is `gcr.io/distroless/static:nonroot`?**
+
+A minimal runtime image containing essentially only: CA certificates, `/etc/passwd`
+with a `nonroot` user (uid 65532), timezone data, and a `/tmp` dir. What it
+*doesn't* have is the point — **no shell, no package manager, no busybox, no
+libc, no coreutils**. That shrinks the attack surface and, crucially, the CVE
+surface: there are no OS packages to be vulnerable. Trivy confirms **0 HIGH/
+CRITICAL in the OS layer** (see Bonus).
+
+**d) `-ldflags='-s -w'` and `-trimpath`?**
+
+`-s` drops the symbol table, `-w` drops DWARF debug info — together they shrink
+the binary and remove most of what a debugger/symbolizer would use. `-trimpath`
+strips absolute build-machine file paths from the binary, replacing them with
+module-relative paths. The cost: `-s -w` makes post-mortem debugging and
+profiling with symbols much harder (no `delve`, degraded stack symbolization);
+`-trimpath` removes local path info that some debug workflows rely on. The payoff
+is a smaller, **reproducible** binary that doesn't leak the build host's directory
+layout — the right trade for a shipped image.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+### Persistence test (real output)
+
+```text
+$ docker compose up --build -d ; docker compose ps --format '{{.Health}}'
+healthy
+
+$ curl -XPOST -d '{"title":"durable","body":"survive a restart"}' :8080/notes      # 201
+present after create:        1
+
+$ docker compose down ; docker compose up -d
+present after down + up:     1     # ✅ survived (named volume kept)
+
+$ docker compose down -v ; docker compose up -d
+present after down -v + up:  0     # gone (volume destroyed)
+```
+
+### 2.2 Design questions
+
+**e) Distroless has no shell — how do you healthcheck it?**
+
+I made the QuickNotes binary **dual-mode**: `quicknotes healthcheck` does an
+in-process HTTP GET to `/health` and exits `0` (healthy) or `1` (unhealthy). The
+Compose healthcheck re-invokes the only binary in the image in exec form:
+`test: ["CMD", "/quicknotes", "healthcheck"]`. No shell, no `wget`, no sidecar.
+This is the lab's "use a binary that's already in the image" option, and it's the
+cleanest — verified: `docker compose ps` reports **healthy**.
+
+**f) Why does the named volume survive `docker compose down`? What destroys it?**
+
+`docker compose down` removes containers and the default network, but **named
+volumes are separate objects with their own lifecycle** — they are intentionally
+left intact so data outlives container churn, and re-attach on the next `up`.
+What destroys it: `docker compose down -v` (or `docker volume rm
+quicknotes-data`). The test above shows exactly this: the note survives `down +
+up` and disappears only after `down -v`.
+
+**g) `depends_on` without `condition: service_healthy`?**
+
+Plain `depends_on: [x]` only waits for container `x` to be **started** (its
+process launched / created), *not* for it to be **ready** to serve. The bug:
+the dependent service can come up and start making requests before `x` is
+actually accepting connections — e.g. an app querying a database that has
+"started" but isn't listening yet, giving intermittent connection-refused races
+on boot. `condition: service_healthy` makes Compose wait for `x`'s healthcheck to
+pass first.
+
+---
+
+## Bonus — The 6 Security Defaults
+
+### Hardened `services.quicknotes` block
+
+```yaml
+read_only: true            # 4. read-only root filesystem
+tmpfs:
+  - /tmp                   #    writable scratch (the /data named volume stays writable)
+cap_drop:
+  - ALL                    # 3. drop every Linux capability (QuickNotes needs none)
+security_opt:
+  - no-new-privileges:true # 5. block setuid privilege escalation
+# 1. USER nonroot  + 2. distroless base  come from app/Dockerfile
+# 6. Trivy scan below
+```
+
+### Verification (real output)
+
+| # | Default | Command | Result |
+|---|---------|---------|--------|
+| 1 | `USER nonroot` | `inspect ... .Config.User` | `nonroot:nonroot` |
+| 2 | No shell | `compose exec quicknotes sh` | `exec: "sh": executable file not found` (fails ✅) |
+| 3 | Caps dropped | `inspect ... .HostConfig.CapDrop` | `[ALL]` |
+| 4 | Read-only root | `inspect ... .HostConfig.ReadonlyRootfs` | `true` |
+| 5 | no-new-privileges | `inspect ... .HostConfig.SecurityOpt` | `[no-new-privileges:true]` |
+
+All five enforced while the service still reports **healthy** and serves
+`/health` — read-only root + dropped caps don't break QuickNotes because it only
+writes to the `/data` volume (and `/tmp` tmpfs).
+
+### Trivy scan
+
+```text
+$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+    aquasec/trivy:0.59.1 image --severity HIGH,CRITICAL --no-progress quicknotes:lab6
+
+quicknotes:lab6 (debian 13.5)      Total: 0  (HIGH: 0, CRITICAL: 0)   # OS layer — clean
+quicknotes (gobinary)              Total: 12 (HIGH: 12, CRITICAL: 0)  # all Go stdlib
+```
+
+The **OS layer has zero HIGH/CRITICAL** — exactly the distroless payoff (no OS
+packages = nothing to patch). The 12 HIGH are all in the **Go standard library**
+compiled into the binary (e.g. `net/url`, `net/mail`, `net/http/httputil`),
+fixed in Go `1.25.8 / 1.26.1`. The lab pins the builder to Go `1.24` (whose
+latest patch `1.24.13` still predates those fixes), so they remain; in a real
+pipeline you'd bump the builder's Go minor version to clear them. Distroless
+fixed the base image; the binary's stdlib is a separate supply-chain axis.
+
+### Most security per line of YAML
+
+**`cap_drop: [ALL]`** — one line strips every Linux capability the container
+would otherwise inherit (~14 by default, including `CAP_NET_RAW`,
+`CAP_CHOWN`, `CAP_SETUID`…), collapsing a huge slice of the kernel attack surface
+that container escapes typically abuse. QuickNotes needs none, so the cost is
+zero. Runner-up is `read_only: true`, which neutralizes persistence/tampering on
+the root filesystem in one line — but `cap_drop: ALL` removes the most latent
+privilege for the least YAML.

--- a/wasm-cli/go.mod
+++ b/wasm-cli/go.mod
@@ -1,0 +1,3 @@
+module moscow-time-cli
+
+go 1.22

--- a/wasm-cli/main.go
+++ b/wasm-cli/main.go
@@ -1,0 +1,57 @@
+// A standalone WASI CLI module — the "CGI over WASM" model. No Spin SDK: the
+// request arrives as environment variables, the response goes to stdout, and the
+// module exits. One process per invocation, run under bare `wasmtime run`.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Same fixed UTC+3 as the Spin component — TinyGo embeds no tzdata.
+var moscow = time.FixedZone("MSK", 3*60*60)
+
+type timeResponse struct {
+	Unix       int64  `json:"unix"`
+	ISO        string `json:"iso"`
+	HourMinute string `json:"hour_minute"`
+	Moscow     string `json:"moscow"`
+	Zone       string `json:"zone"`
+}
+
+func main() {
+	method := os.Getenv("REQUEST_METHOD")
+	path := os.Getenv("PATH_INFO")
+
+	if method != "" && method != "GET" {
+		fmt.Println("Status: 405 Method Not Allowed")
+		fmt.Println()
+		return
+	}
+	if path != "" && path != "/time" {
+		fmt.Println("Status: 404 Not Found")
+		fmt.Println()
+		return
+	}
+
+	now := time.Now().In(moscow)
+	body, err := json.Marshal(timeResponse{
+		Unix:       now.Unix(),
+		ISO:        now.Format(time.RFC3339),
+		HourMinute: now.Format("15:04"),
+		Moscow:     now.Format("2006-01-02 15:04:05"),
+		Zone:       "Europe/Moscow (UTC+3)",
+	})
+	if err != nil {
+		fmt.Println("Status: 500 Internal Server Error")
+		fmt.Println()
+		return
+	}
+
+	// CGI-shaped response: headers, blank line, body.
+	fmt.Println("Content-Type: application/json")
+	fmt.Println()
+	fmt.Println(string(body))
+}

--- a/wasm/moscow-time/.gitignore
+++ b/wasm/moscow-time/.gitignore
@@ -1,0 +1,2 @@
+main.wasm
+.spin/

--- a/wasm/moscow-time/go.mod
+++ b/wasm/moscow-time/go.mod
@@ -1,0 +1,7 @@
+module github.com/moscow_time
+
+go 1.22
+
+require github.com/spinframework/spin-go-sdk/v2 v2.2.1
+
+require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/wasm/moscow-time/go.sum
+++ b/wasm/moscow-time/go.sum
@@ -1,0 +1,4 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1 h1:ceAbRU+D3xmyZ8ScDLeFoT763ikFIUEmSjgsrD11v8k=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1/go.mod h1:vocVZB4qlTG8C5yoliKIAJCuv4x7sqK0GmVkWeD9N/A=

--- a/wasm/moscow-time/main.go
+++ b/wasm/moscow-time/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	spinhttp "github.com/spinframework/spin-go-sdk/v2/http"
+)
+
+// Moscow has been a fixed UTC+3 with no DST since 2014. We use a FixedZone
+// rather than time.LoadLocation("Europe/Moscow") because TinyGo embeds no
+// tzdata at all — LoadLocation would fail at runtime inside the wasm module.
+var moscow = time.FixedZone("MSK", 3*60*60)
+
+// A concrete struct (not map[string]any): TinyGo's reflection support is
+// limited, and reflection-heavy encoding of dynamic maps is a known rough edge.
+type timeResponse struct {
+	Unix       int64  `json:"unix"`
+	ISO        string `json:"iso"`
+	HourMinute string `json:"hour_minute"`
+	Moscow     string `json:"moscow"`
+	Zone       string `json:"zone"`
+}
+
+func init() {
+	spinhttp.Handle(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		now := time.Now().In(moscow)
+		resp := timeResponse{
+			Unix:       now.Unix(),
+			ISO:        now.Format(time.RFC3339),
+			HourMinute: now.Format("15:04"),
+			Moscow:     now.Format("2006-01-02 15:04:05"),
+			Zone:       "Europe/Moscow (UTC+3)",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+}
+
+// main must exist for the compiler, but it is never executed: the Spin host
+// invokes the handler registered in init() through the component's export.
+func main() {}

--- a/wasm/moscow-time/spin.toml
+++ b/wasm/moscow-time/spin.toml
@@ -1,0 +1,21 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
+spin_manifest_version = 2
+
+[application]
+name = "moscow-time"
+version = "0.1.0"
+authors = ["rikire <rizireY@yandex.ru>"]
+description = "Moscow-time endpoint as a WebAssembly component (Lab 12)"
+
+[[trigger.http]]
+route = "/time"
+component = "moscow-time"
+
+[component.moscow-time]
+source = "main.wasm"
+# Least privilege: the component may not open ANY outbound connection.
+allowed_outbound_hosts = []
+[component.moscow-time.build]
+command = "tinygo build -target=wasip1 -buildmode=c-shared -no-debug -o main.wasm ."
+watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
## Summary

Ports a QuickNotes endpoint to WebAssembly: a Spin wasi-http component serving
`GET /time` (Moscow time as JSON), benchmarked against the Lab 6 container, plus
the Bonus standalone WASI CLI module.

Report: `submissions/lab12.md`

## What's here

- **`wasm/moscow-time/`** — the Spin component. `route = "/time"`,
  `allowed_outbound_hosts = []` (no outbound capability granted at all), built with
  `tinygo build -target=wasip1 -buildmode=c-shared` so the module *exports* a
  handler rather than a `_start`.
- **`wasm-cli/`** — Bonus: the same logic as a CGI-shaped WASI module under bare
  `wasmtime run`.

## Measured results (vs the Lab 6 container)

| | Docker (Lab 6) | WASM/Spin |
|---|---:|---:|
| Artifact | 8.61 MB | **0.49 MB** |
| Cold start (p50, n=5) | 480 ms | **83 ms** |
| Warm latency p50 / p95 | **6.53 / 7.77 ms** | 8.54 / 9.71 ms |

WASM is ~17× smaller and cold-starts ~6× faster — but the native container is ~25%
faster once warm. The trade-off cuts both ways, and the report says so.

## Notes from doing it

- **Spin 4.x is pinned back to 3.4.0 on purpose.** The 4.x `http-go` template has
  moved off TinyGo to `go tool componentize-go build` and fails out of the box with
  `failed to read path for WIT [wit]` — it expects a `wit/` directory the scaffold
  never creates. Spin 3.4 is the version this lab was validated against.
- Two TinyGo stdlib gaps hit and worked around: no tzdata (`time.FixedZone` instead
  of `LoadLocation`) and limited reflection (a concrete struct instead of
  `map[string]any` for the JSON body).
- The Spin component under bare `wasmtime run` exits 0 and prints nothing — it
  exports a wasi-http handler, not a CLI entrypoint. Included as evidence for the
  Bonus design questions.

Build artifacts (`*.wasm`, `.spin/`) are gitignored — both are reproduced by
`spin build` / `tinygo build`.
