### PR TITLE
feature/lab11

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+﻿## Goal
+<!-- What does this PR accomplish? 1 sentence. -->
+
+## Changes
+- 
+
+## Testing
+<!-- How did you verify it? -->
+
+## Checklist
+- [ ] Title is a clear sentence (≤ 70 chars)
+- [ ] Commits are signed (`git log --show-signature`)
+- [ ] `submissions/labN.md` updated

--- a/.github/workflows/nix-repro.yml
+++ b/.github/workflows/nix-repro.yml
@@ -1,0 +1,52 @@
+name: nix-repro
+
+# Bonus: prove reproducibility in CI. Two independent runners each build the
+# Nix OCI image; a third job fails the workflow unless the two SHA-256 digests
+# match. Reproducibility you can't prove in CI is folklore.
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-a:
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.d.outputs.digest }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.2.2
+      - uses: DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e  # v9
+      - id: d
+        run: |
+          nix build .#docker
+          echo "digest=$(sha256sum result | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+  build-b:
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.d.outputs.digest }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.2.2
+      - uses: DeterminateSystems/nix-installer-action@cd46bde16ab981b0a7b2dce0574509104543276e  # v9
+      - id: d
+        run: |
+          nix build .#docker
+          echo "digest=$(sha256sum result | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+  compare:
+    needs: [build-a, build-b]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assert the two digests match
+        run: |
+          A='${{ needs.build-a.outputs.digest }}'
+          B='${{ needs.build-b.outputs.digest }}'
+          echo "build-a: $A"
+          echo "build-b: $B"
+          if [ "$A" = "$B" ]; then
+            echo "✅ reproducible: identical digests on two independent runners"
+          else
+            echo "❌ NON-reproducible: digests differ"; exit 1
+          fi

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,7 @@
+# keep the build context small and cache-friendly
+data/
+quicknotes
+*.exe
+*_test.go
+Dockerfile
+.dockerignore

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder stage: full Go toolchain, produces a static stripped binary ----
+FROM golang:1.24 AS build
+WORKDIR /src
+
+# go.mod first (no go.sum: QuickNotes has zero third-party deps) so this layer
+# is cached and only re-runs when the module file actually changes.
+COPY go.mod ./
+RUN go mod download
+
+# now the source — changing code invalidates only from here down
+COPY . .
+
+# CGO off => a fully static binary that needs no libc / dynamic linker, which is
+# exactly what distroless-static expects. -trimpath + -ldflags '-s -w' strip the
+# build for a smaller, reproducible binary.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags='-s -w' -o /qn .
+
+# a tiny health probe binary (distroless has no shell/curl/wget to healthcheck with).
+# Built here, copied into the runtime image, invoked by HEALTHCHECK.
+RUN <<'EOF'
+set -e
+cat > /tmp/healthcheck.go <<'GO'
+package main
+
+import (
+	"net/http"
+	"os"
+)
+
+func main() {
+	resp, err := http.Get("http://127.0.0.1:8080/health")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}
+GO
+CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /healthcheck /tmp/healthcheck.go
+# /data created here so the runtime image owns it as nonroot; a named volume
+# mounted over it inherits this ownership, so UID 65532 can write notes.json.
+mkdir -p /data
+EOF
+
+# ---- runtime stage: distroless static, nonroot, no shell, no package manager ----
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=build /qn /qn
+COPY --from=build /healthcheck /healthcheck
+COPY --from=build /src/seed.json /seed.json
+COPY --from=build --chown=65532:65532 /data /data
+
+ENV ADDR=":8080" \
+    DATA_PATH="/data/notes.json" \
+    SEED_PATH="/seed.json"
+
+EXPOSE 8080
+USER nonroot:nonroot
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["/healthcheck"]
+
+ENTRYPOINT ["/qn"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  quicknotes:
+    build: ./app
+    image: quicknotes:lab6
+    ports:
+      # host port defaults to 8080; override with QN_HOST_PORT if 8080 is taken
+      - "${QN_HOST_PORT:-8080}:8080"
+    environment:
+      ADDR: ":8080"
+      DATA_PATH: "/data/notes.json"
+      SEED_PATH: "/seed.json"
+    volumes:
+      - quicknotes-data:/data        # named volume: survives `down`, dies on `down -v`
+    healthcheck:
+      test: ["CMD", "/healthcheck"]   # distroless has no shell, so we ship a probe binary
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+    # ---- Bonus: the 6 security defaults ----
+    # 1. USER nonroot          -> set in the Dockerfile (UID 65532)
+    # 2. distroless base       -> set in the Dockerfile (no shell / no pkg manager)
+    # 3. drop all capabilities -> QuickNotes needs none
+    cap_drop:
+      - ALL
+    # 4. read-only root fs, with tmpfs for the only writable scratch path
+    read_only: true
+    tmpfs:
+      - /tmp
+    # 5. no privilege escalation
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  quicknotes-data:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "QuickNotes — reproducible Go build + deterministic OCI image (Lab 11)";
+
+  # flake.lock pins this to an exact nixpkgs revision → the single source of
+  # reproducibility across machines.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+      quicknotes = pkgs.buildGoModule {
+        pname = "quicknotes";
+        version = "0.1.0";
+        src = ./app;
+        # QuickNotes has zero third-party deps, so there is nothing to vendor.
+        vendorHash = null;
+        CGO_ENABLED = 0;              # static binary
+        ldflags = [ "-s" "-w" ];      # strip (size + reproducibility); -trimpath is default
+      };
+    in
+    {
+      packages.${system} = {
+        default = quicknotes;
+        quicknotes = quicknotes;
+
+        # Deterministic OCI image built by Nix (no Docker daemon involved).
+        # dockerTools.buildImage pins layer timestamps to the epoch, so two
+        # independent builds produce an identical tarball digest.
+        docker = pkgs.dockerTools.buildImage {
+          name = "quicknotes-nix";
+          tag = "latest";
+          # minimal image has no /tmp; the nonroot app writes DATA_PATH there
+          extraCommands = "mkdir -p tmp && chmod 1777 tmp";
+          config = {
+            Entrypoint = [ "${quicknotes}/bin/quicknotes" ];
+            ExposedPorts = { "8080/tcp" = { }; };
+            User = "65534:65534";     # nobody:nobody — nonroot (Lab 6 discipline)
+            Env = [
+              "ADDR=:8080"
+              "DATA_PATH=/tmp/notes.json"
+              "SEED_PATH=/seed.json"
+            ];
+          };
+        };
+      };
+
+      # `nix develop` drops collaborators into a shell with the Go toolchain.
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [ pkgs.go pkgs.gopls pkgs.golangci-lint ];
+      };
+    };
+}

--- a/submissions/lab11.md
+++ b/submissions/lab11.md
@@ -1,0 +1,178 @@
+# Lab 11
+
+Files: [`flake.nix`](../flake.nix), [`flake.lock`](../flake.lock),
+[`.github/workflows/nix-repro.yml`](../.github/workflows/nix-repro.yml).
+
+---
+
+## Task 1 - Reproducible Go build via Nix flake
+
+`flake.nix` pins `nixpkgs` to nixos-25.05 (via `flake.lock`), exposes
+`packages.quicknotes` (+ `default`) built with `buildGoModule` from `./app`,
+with `CGO_ENABLED = 0` (static), `vendorHash = null` (QuickNotes has zero
+third-party deps), and `ldflags = ["-s" "-w"]`. A `devShell` provides `go`,
+`gopls`, `golangci-lint`.
+
+> nixos-24.11 ships Go 1.23, but `go.mod` requires `go 1.24` and Nix pins
+> `GOTOOLCHAIN=local` (no network toolchain download) - so I bumped the channel to
+> nixos-25.05, which ships Go 1.24.
+
+### Build + run
+
+```
+$ nix build .#quicknotes          # inside nixos/nix, nixpkgs pinned via flake.lock
+$ ls -l result/bin/quicknotes
+-r-xr-xr-x 1 root root 5863824 Jan  1  1970 quicknotes   # note: epoch mtime (deterministic)
+$ DATA_PATH=/tmp/notes.json SEED_PATH=app/seed.json ./result/bin/quicknotes &
+   quicknotes listening on :8080 (notes loaded: 4)
+$ curl -s localhost:8080/health
+{"notes":4,"status":"ok"}
+```
+
+### Reproducibility - two independent builds, identical store hash
+
+Built in two independent environments (env A = a persisted `/nix` volume; env B =
+a fresh `docker run --rm` with an empty store that re-downloads everything), each
+`nix-store --query --hash $(readlink result)`:
+```
+env A:  sha256:1z6fc78k06d931jpv8r795010mm4k6kizd1nkkdrcv97anr8ma7s
+env B:  sha256:1z6fc78k06d931jpv8r795010mm4k6kizd1nkkdrcv97anr8ma7s
+        → IDENTICAL ✅
+```
+
+### 1.3 Design questions
+
+a) Why doesn't `go build` produce bit-identical outputs on two machines from the
+same Git SHA? Without `-trimpath` the binary embeds absolute build paths
+(`/home/you/...`), and Go embeds a build ID derived from those inputs; VCS
+stamping (`-buildvcs`) bakes in git state/time; and a different Go compiler
+version emits different code. Same source ≠ same bytes unless you pin the
+toolchain and strip paths/timestamps - which is exactly what Nix + `-trimpath` +
+`-s -w` do.
+
+b) `vendorHash` is a SHA over what? Over the entire vendored dependency
+tree - the fixed-output hash of what `go mod vendor` produces (all module
+sources, normalized). It makes the dependency fetch hermetic: the build only
+succeeds if the deps hash to exactly that value. `vendorHash = null` tells
+`buildGoModule` there are no deps to vendor - correct for QuickNotes (zero
+deps); for a module with dependencies, `null` fails the build because it skips
+fetching them.
+
+c) Why is `flake.lock` the single most important file for reproducibility? It
+pins `nixpkgs` to an exact git revision, which fixes the entire build graph -
+the Go compiler, stdlib, build tools, `dockerTools` - to identical bytes across
+machines and time. Delete it before the second build and Nix re-resolves
+`nixos-25.05` to whatever the branch tip is now (a different revision → maybe a
+different Go point release) → the output hash can change. The lock is what makes
+"same inputs" literally true.
+
+d) `buildGoModule` vs `buildGoApplication`? `buildGoModule` (in nixpkgs)
+vendors all deps through one fixed-output derivation keyed by `vendorHash` - simple,
+self-contained, no extra tooling. `buildGoApplication` (from `gomod2nix`) builds
+each dependency as its own Nix derivation from a generated `gomod2nix.toml` - finer
+caching, no single `vendorHash`, but adds a codegen step and a non-nixpkgs input.
+For QuickNotes (zero deps, stay in nixpkgs, minimal moving parts) `buildGoModule`
+with `vendorHash = null` is the right pick.
+
+---
+
+## Task 2 - Deterministic OCI image
+
+`flake.nix` also exposes `packages.docker` via `pkgs.dockerTools.buildImage` -
+built entirely by Nix, no Docker daemon. It sets the QuickNotes binary as the
+exec-form `Entrypoint`, `ExposedPorts` `8080/tcp`, and runs as `65534:65534`
+(nonroot). `dockerTools` pins all layer mtimes to the epoch, so the tarball is
+byte-deterministic.
+
+### Two independent builds → identical SHA-256
+
+```
+$ nix build .#docker && sha256sum result
+env A:  c27cf6d02f9a33f219d6176cb47c1c3b70a0d0665592b31346591577658c6478
+env B:  c27cf6d02f9a33f219d6176cb47c1c3b70a0d0665592b31346591577658c6478
+        → IDENTICAL ✅
+```
+`docker load < result` → `quicknotes-nix:latest`. The image is intentionally
+minimal (no `/tmp`), so it's run with a writable scratch mount -
+`docker run --tmpfs /tmp:rw,mode=1777 ...` (the same read-only-rootfs + tmpfs
+pattern as Lab 6) → `/health` → `{"notes":0,"status":"ok"}`.
+
+### Contrast: Lab 6 `docker build --no-cache` twice → digests differ
+
+```
+$ docker build --no-cache -t qn-lab6:run1 ./app
+$ docker build --no-cache -t qn-lab6:run2 ./app
+$ docker images --no-trunc qn-lab6
+run1  sha256:1f7a2de2d8fbce750eb1f706f8c17b3dd6db6455adef3d57bf7a7cdac4859131
+run2  sha256:f70c38c935beb8a22606582fd6f1cd2363131317ee8fd0a6a6612c5e4b794008
+        → DIFFER (layer/image timestamps) - non-reproducible
+```
+
+### Size comparison
+
+| Artifact | Size |
+|----------|------|
+| Nix `dockerTools` image | 21.4 MB loaded (3.0 MB tar) |
+| Lab 6 `docker build` image | 22.7 MB |
+| static Go binary | 5.6 MB |
+
+### 2.4 Design questions
+
+e) What does `docker build` do that's non-deterministic? It stamps a
+creation timestamp on the image and records layer mtimes at build time; `RUN`
+steps execute at build time so their filesystem output carries fresh timestamps
+(and can fetch changing content, e.g. `apt`); tar ordering/metadata vary. So the
+same Dockerfile + SHA yields different layer digests. `dockerTools.buildImage`
+avoids all of this: epoch mtimes, no "now" created date, and inputs are already
+deterministic Nix store paths.
+
+f) What can a reproducible image prove that a signed-but-non-reproducible one
+can't? A reproducible image lets an auditor rebuild from source and get the
+identical digest - proving the published artifact corresponds exactly to this
+source (no tampering slipped in between source and registry). A signature only
+proves who published it and that it wasn't altered after signing - a
+compromised build pipeline can sign a backdoored image. Reproducibility closes the
+source→artifact gap; signing closes the artifact→publisher gap.
+
+g) The trade-off of Nix's reproducibility? A steep learning curve and a whole
+new language/model; every build step must be pure (no ad-hoc `RUN curl | sh`);
+onboarding and ecosystem friction (not everything is packaged); a large Nix store.
+`docker build` stays the default because it's simple, ubiquitous, matches the
+imperative mental model devs already have, and is "good enough" - most teams don't
+*require* bit-for-bit determinism. Nix earns its cost when supply-chain integrity
+is a hard requirement.
+
+---
+
+## Bonus - CI-verified reproducibility
+
+[`nix-repro.yml`](../.github/workflows/nix-repro.yml): on push/PR, two parallel
+jobs (`build-a`, `build-b`) on separate fresh runners each `nix build .#docker`
+and export `sha256sum result`; a third `compare` job fails the workflow unless
+the two digests match. The Nix-installer action is SHA-pinned (`v9`).
+
+> The green run shows two equal digests; a red run is produced by, e.g., injecting
+> a different `SOURCE_DATE_EPOCH` into one job so its layer mtimes differ → digests
+> diverge → `compare` exits non-zero.
+
+### B.4 Design questions
+
+h) "Reproducible on my laptop" vs "in CI". Your laptop carries hidden state - a
+warm Nix store, env vars, installed tools - so two local builds can match merely
+because they *share cached artifacts*, not because the build is deterministic. CI
+runners are fresh and isolated; identical digests there prove reproducibility
+from clean inputs, which is what lets an auditor independently rebuild and verify.
+
+i) Why two parallel jobs, not one job building twice? Two parallel jobs run on
+separate runners - genuinely independent (no shared `/nix` store or
+filesystem). One job that builds twice shares the same store, so the second build
+just returns the cached first result - identical by construction, testing
+nothing. A single-job comparison would miss machine- or cache-masked nondeterminism.
+
+j) `SOURCE_DATE_EPOCH` - where would the timestamp leak in, and how does
+`dockerTools` handle it? In an image build the timestamp normally leaks via the
+image `created` date and the layer file mtimes in the tarball (plus any tool
+that stamps "now"). `dockerTools.buildImage` neutralizes it: it sets all mtimes to
+the epoch (1970-01-01) and doesn't record a live "created" date, so the tarball is
+byte-identical no matter when it's built - `SOURCE_DATE_EPOCH` is effectively
+baked to 0.

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,0 +1,168 @@
+# Lab 6 — Containers: Dockerize QuickNotes
+
+Built and tested for real with Docker 29.1.3 + Compose v2.40. My Windows host
+already runs Docker Desktop on `:8080`, so I ran the engine inside WSL2 (Ubuntu
+24.04) and published the compose service on host port 18080 for the live tests —
+the committed `compose.yaml` still defaults to 8080 (`${QN_HOST_PORT:-8080}:8080`).
+
+Files: [`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
+
+---
+
+## Task 1 — Multi-stage Dockerfile, ≤ 25 MB
+
+The Dockerfile is multi-stage: a `golang:1.24` builder that produces a static,
+stripped binary, and a `gcr.io/distroless/static:nonroot` runtime with no shell
+or package manager. `go.mod` is copied before the source so the dependency layer
+stays cached. A tiny static Go probe binary is built alongside the app to act as
+the healthcheck (distroless has nothing to curl/wget with).
+
+**Size — `docker images` (requirement: ≤ 25 MB):**
+```
+REPOSITORY:TAG    SIZE
+quicknotes:lab6   22.7MB
+```
+For comparison, the builder base is `golang:1.24 = 1.32GB` — the multi-stage build
+ships ~1.5% of that.
+
+**`docker inspect` (User / ExposedPorts / Entrypoint / Env):**
+```json
+{
+  "User": "nonroot:nonroot",
+  "ExposedPorts": { "8080/tcp": {} },
+  "Entrypoint": ["/qn"],
+  "Env": ["...", "ADDR=:8080", "DATA_PATH=/data/notes.json", "SEED_PATH=/seed.json"]
+}
+```
+
+**Run + health (from the host):**
+```
+GET /health -> {"notes":4,"status":"ok"}
+container health: healthy
+```
+
+### Design questions
+
+**a) Why does layer order matter? (measured rebuild times)**
+Measured on this Dockerfile:
+
+| Build | Time |
+|-------|-----:|
+| Clean build (`--no-cache`) | 22.76 s |
+| Rebuild, no change (full cache hit) | 3.11 s |
+| Rebuild after a source change (go.mod layer stays cached) | 22.62 s |
+
+Docker caches each instruction layer and reuses it until something it depends on
+changes. By copying `go.mod` and running `go mod download` *before* `COPY . .`,
+a source-only change can't invalidate the dependency layer — the
+`COPY go.mod && download` strategy keeps deps cached, while the naive
+`COPY . . && download && build` re-downloads everything on any file change.
+Here the two strategies come out almost equal (22.6 s vs 22.8 s) for an honest
+reason: QuickNotes has **zero third-party dependencies**, so `go mod download`
+costs nothing and the cached layer saves nothing — the ~22 s is the Go *compile*,
+which re-runs on any source change either way. On a real project with a big
+`go.sum`, the dependency layer is the expensive one, and that's where correct
+ordering turns a multi-minute rebuild into seconds (as the no-change cache hit at
+3.11 s hints).
+
+**b) Why `CGO_ENABLED=0`?** It forces a fully static binary with Go's pure-Go
+implementations (net, crypto) instead of linking libc. `distroless/static` has no
+dynamic linker and no shared libraries, so a CGO-enabled (dynamically linked)
+binary would build fine but **crash at container start** with something like
+`no such file or directory` / missing `ld-linux` — the kernel can't find the
+loader the binary asks for. Static = nothing to link against at runtime.
+
+**c) What is `gcr.io/distroless/static:nonroot`?** A ~2 MB base that contains
+only what a static binary needs at runtime: CA certificates, `/etc/passwd` with a
+`nonroot` user (UID 65532), timezone data, and `/tmp` — and nothing else. No
+shell, no `apt`, no busybox, no libc. Because there are no OS packages, there's
+almost no CVE surface: Trivy reported **0 HIGH/CRITICAL OS vulnerabilities** for
+the base (see Bonus). Fewer things in the image = fewer things to patch and fewer
+ways in.
+
+**d) `-ldflags='-s -w'` and `-trimpath`.** `-s` drops the symbol table and `-w`
+drops DWARF debug info, shrinking the binary; the cost is you can't get symbolized
+stack traces or run a debugger against it. `-trimpath` removes absolute build-machine
+paths (like `/home/me/go/...`) from the binary, which makes builds reproducible and
+avoids leaking local paths; the cost is panic traces show trimmed module paths
+instead of full local paths. Both are standard for release/container builds.
+
+---
+
+## Task 2 — Compose + Healthcheck + Persistent Volume
+
+`compose.yaml` builds from `./app`, tags `quicknotes:lab6`, mounts a named volume
+at `/data`, sets `ADDR`/`DATA_PATH`/`SEED_PATH`, declares a healthcheck, and uses
+`restart: unless-stopped`.
+
+**Persistence test (on host port 18080):**
+```
+create a note  -> {"id":5,"title":"durable",...}
+grep durable                       -> durable      # present
+docker compose down  (keep volume)
+docker compose up    -> grep durable -> durable    # SURVIVED a restart
+docker compose down -v  (destroy volume)
+docker compose up    -> grep durable -> GONE       # volume destroyed
+```
+
+### Design questions
+
+**e) Distroless has no shell — how do you healthcheck it?** A `CMD-SHELL`
+healthcheck (and `curl`/`wget` ones) can't work because there's no shell or those
+binaries in the image. My choice: **ship a tiny static Go probe binary** built in
+the same builder stage, copied to `/healthcheck`, and called with the exec-form
+`HEALTHCHECK CMD ["/healthcheck"]`. It does an HTTP GET to `127.0.0.1:8080/health`
+and exits 0/1. Verified: the container reports `healthy`. (Other options I
+rejected: a wget-only debug base — defeats the point of distroless; or relying on
+Docker only checking the process is alive — that doesn't catch a hung server.)
+
+**f) Why does the named volume survive `docker compose down`?** `down` removes the
+containers and the default network, but **named volumes are deliberately left
+alone** — they're treated as data you want to keep. The note is stored in the
+`quicknotes-data` volume, not the container's writable layer, so it's still there
+after `down` + `up`. What destroys it: `docker compose down -v` (or
+`docker volume rm quicknotes-data`) — shown above, the note was gone afterward.
+
+**g) `depends_on` without `condition: service_healthy`.** Plain `depends_on` only
+waits for the dependency container to **start** (be created and running), not for
+the app inside to be **ready**. So a dependent service can start connecting while
+the dependency is still booting and not yet accepting requests — a startup race
+that shows up as flaky "connection refused" on cold starts. `condition:
+service_healthy` makes Compose wait for the healthcheck to pass first.
+
+---
+
+## Bonus — The 6 Security Defaults (all applied + verified)
+
+| # | Default | Evidence |
+|---|---------|----------|
+| 1 | `USER nonroot` | `docker inspect ... .Config.User` → `nonroot:nonroot` |
+| 2 | Distroless base (no shell) | `docker compose exec quicknotes sh` → `exec: "sh": executable file not found in $PATH` |
+| 3 | Drop all capabilities | `.HostConfig.CapDrop` → `[ALL]` |
+| 4 | Read-only root + tmpfs | `.HostConfig.ReadonlyRootfs` → `true`, `Tmpfs` → `map[/tmp:]` |
+| 5 | `no-new-privileges` | `.HostConfig.SecurityOpt` → `[no-new-privileges:true]` |
+| 6 | Trivy scan | see below |
+
+**Trivy (`--severity HIGH,CRITICAL`):**
+```
+quicknotes:lab6 (debian 13.5)        Total: 0 (HIGH: 0, CRITICAL: 0)   # distroless OS packages
+/qn  (gobinary)                      Total: 12 (HIGH: 12, CRITICAL: 0) # Go stdlib
+```
+Honest reading: the **distroless base contributes zero OS-package CVEs** — that's
+the whole point of a minimal base. The 12 HIGH are all in the **Go standard
+library compiled into the binary** (net/http ReverseProxy, MIME-header DoS, etc.),
+flagged because the task pins the builder to `golang:1.24`; they're fixed in Go
+1.25.11 / 1.26.4, so bumping the toolchain would clear them — but the lab requires
+the builder pinned to 1.24, so I kept it and documented the trade-off. The lesson:
+distroless removes the OS attack surface, but your application's own toolchain
+version is still your responsibility.
+
+---
+
+## Summary
+
+| Task | Result |
+|------|--------|
+| 1 — Dockerfile ≤ 25 MB | multi-stage, distroless nonroot, static stripped binary; `docker images` = **22.7 MB**; healthy `200` |
+| 2 — Compose + volume | named volume survives `down`, dies on `down -v`; Go-probe healthcheck → `healthy` |
+| Bonus — 6 defaults | nonroot, distroless, `cap_drop ALL`, read-only+tmpfs, no-new-privileges, Trivy (0 OS CVEs) — all verified |

--- a/submissions/lab6.md
+++ b/submissions/lab6.md
@@ -1,10 +1,5 @@
 # Lab 6 — Containers: Dockerize QuickNotes
 
-Built and tested for real with Docker 29.1.3 + Compose v2.40. My Windows host
-already runs Docker Desktop on `:8080`, so I ran the engine inside WSL2 (Ubuntu
-24.04) and published the compose service on host port 18080 for the live tests —
-the committed `compose.yaml` still defaults to 8080 (`${QN_HOST_PORT:-8080}:8080`).
-
 Files: [`app/Dockerfile`](../app/Dockerfile), [`compose.yaml`](../compose.yaml).
 
 ---
@@ -17,7 +12,7 @@ or package manager. `go.mod` is copied before the source so the dependency layer
 stays cached. A tiny static Go probe binary is built alongside the app to act as
 the healthcheck (distroless has nothing to curl/wget with).
 
-**Size — `docker images` (requirement: ≤ 25 MB):**
+Size — `docker images` (requirement: ≤ 25 MB):
 ```
 REPOSITORY:TAG    SIZE
 quicknotes:lab6   22.7MB
@@ -25,7 +20,7 @@ quicknotes:lab6   22.7MB
 For comparison, the builder base is `golang:1.24 = 1.32GB` — the multi-stage build
 ships ~1.5% of that.
 
-**`docker inspect` (User / ExposedPorts / Entrypoint / Env):**
+`docker inspect` (User / ExposedPorts / Entrypoint / Env):
 ```json
 {
   "User": "nonroot:nonroot",
@@ -35,7 +30,7 @@ ships ~1.5% of that.
 }
 ```
 
-**Run + health (from the host):**
+Run + health (from the host):
 ```
 GET /health -> {"notes":4,"status":"ok"}
 container health: healthy
@@ -43,7 +38,7 @@ container health: healthy
 
 ### Design questions
 
-**a) Why does layer order matter? (measured rebuild times)**
+a) Why does layer order matter? (measured rebuild times)
 Measured on this Dockerfile:
 
 | Build | Time |
@@ -57,30 +52,23 @@ changes. By copying `go.mod` and running `go mod download` *before* `COPY . .`,
 a source-only change can't invalidate the dependency layer — the
 `COPY go.mod && download` strategy keeps deps cached, while the naive
 `COPY . . && download && build` re-downloads everything on any file change.
-Here the two strategies come out almost equal (22.6 s vs 22.8 s) for an honest
-reason: QuickNotes has **zero third-party dependencies**, so `go mod download`
-costs nothing and the cached layer saves nothing — the ~22 s is the Go *compile*,
-which re-runs on any source change either way. On a real project with a big
-`go.sum`, the dependency layer is the expensive one, and that's where correct
-ordering turns a multi-minute rebuild into seconds (as the no-change cache hit at
-3.11 s hints).
 
-**b) Why `CGO_ENABLED=0`?** It forces a fully static binary with Go's pure-Go
+b) Why `CGO_ENABLED=0`? It forces a fully static binary with Go's pure-Go
 implementations (net, crypto) instead of linking libc. `distroless/static` has no
 dynamic linker and no shared libraries, so a CGO-enabled (dynamically linked)
-binary would build fine but **crash at container start** with something like
+binary would build fine but crash at container start with something like
 `no such file or directory` / missing `ld-linux` — the kernel can't find the
 loader the binary asks for. Static = nothing to link against at runtime.
 
-**c) What is `gcr.io/distroless/static:nonroot`?** A ~2 MB base that contains
+c) What is `gcr.io/distroless/static:nonroot`? A ~2 MB base that contains
 only what a static binary needs at runtime: CA certificates, `/etc/passwd` with a
 `nonroot` user (UID 65532), timezone data, and `/tmp` — and nothing else. No
 shell, no `apt`, no busybox, no libc. Because there are no OS packages, there's
-almost no CVE surface: Trivy reported **0 HIGH/CRITICAL OS vulnerabilities** for
+almost no CVE surface: Trivy reported 0 HIGH/CRITICAL OS vulnerabilities for
 the base (see Bonus). Fewer things in the image = fewer things to patch and fewer
 ways in.
 
-**d) `-ldflags='-s -w'` and `-trimpath`.** `-s` drops the symbol table and `-w`
+d) `-ldflags='-s -w'` and `-trimpath`. `-s` drops the symbol table and `-w`
 drops DWARF debug info, shrinking the binary; the cost is you can't get symbolized
 stack traces or run a debugger against it. `-trimpath` removes absolute build-machine
 paths (like `/home/me/go/...`) from the binary, which makes builds reproducible and
@@ -95,7 +83,7 @@ instead of full local paths. Both are standard for release/container builds.
 at `/data`, sets `ADDR`/`DATA_PATH`/`SEED_PATH`, declares a healthcheck, and uses
 `restart: unless-stopped`.
 
-**Persistence test (on host port 18080):**
+Persistence test (on host port 18080):
 ```
 create a note  -> {"id":5,"title":"durable",...}
 grep durable                       -> durable      # present
@@ -107,25 +95,23 @@ docker compose up    -> grep durable -> GONE       # volume destroyed
 
 ### Design questions
 
-**e) Distroless has no shell — how do you healthcheck it?** A `CMD-SHELL`
+e) Distroless has no shell — how do you healthcheck it? A `CMD-SHELL`
 healthcheck (and `curl`/`wget` ones) can't work because there's no shell or those
-binaries in the image. My choice: **ship a tiny static Go probe binary** built in
+binaries in the image. Ship a tiny static Go probe binary built in
 the same builder stage, copied to `/healthcheck`, and called with the exec-form
 `HEALTHCHECK CMD ["/healthcheck"]`. It does an HTTP GET to `127.0.0.1:8080/health`
-and exits 0/1. Verified: the container reports `healthy`. (Other options I
-rejected: a wget-only debug base — defeats the point of distroless; or relying on
-Docker only checking the process is alive — that doesn't catch a hung server.)
+and exits 0/1. Verified: the container reports `healthy`.
 
-**f) Why does the named volume survive `docker compose down`?** `down` removes the
-containers and the default network, but **named volumes are deliberately left
-alone** — they're treated as data you want to keep. The note is stored in the
+f) Why does the named volume survive `docker compose down`? `down` removes the
+containers and the default network, but named volumes are deliberately left
+alone — they're treated as data you want to keep. The note is stored in the
 `quicknotes-data` volume, not the container's writable layer, so it's still there
 after `down` + `up`. What destroys it: `docker compose down -v` (or
-`docker volume rm quicknotes-data`) — shown above, the note was gone afterward.
+`docker volume rm quicknotes-data`), the note was gone afterward.
 
-**g) `depends_on` without `condition: service_healthy`.** Plain `depends_on` only
-waits for the dependency container to **start** (be created and running), not for
-the app inside to be **ready**. So a dependent service can start connecting while
+g) `depends_on` without `condition: service_healthy`. Plain `depends_on` only
+waits for the dependency container to start (be created and running), not for
+the app inside to be ready. So a dependent service can start connecting while
 the dependency is still booting and not yet accepting requests — a startup race
 that shows up as flaky "connection refused" on cold starts. `condition:
 service_healthy` makes Compose wait for the healthcheck to pass first.
@@ -143,26 +129,16 @@ service_healthy` makes Compose wait for the healthcheck to pass first.
 | 5 | `no-new-privileges` | `.HostConfig.SecurityOpt` → `[no-new-privileges:true]` |
 | 6 | Trivy scan | see below |
 
-**Trivy (`--severity HIGH,CRITICAL`):**
+Trivy (`--severity HIGH,CRITICAL`):
 ```
 quicknotes:lab6 (debian 13.5)        Total: 0 (HIGH: 0, CRITICAL: 0)   # distroless OS packages
 /qn  (gobinary)                      Total: 12 (HIGH: 12, CRITICAL: 0) # Go stdlib
 ```
-Honest reading: the **distroless base contributes zero OS-package CVEs** — that's
-the whole point of a minimal base. The 12 HIGH are all in the **Go standard
-library compiled into the binary** (net/http ReverseProxy, MIME-header DoS, etc.),
+Honest reading: the distroless base contributes zero OS-package CVEs.
+The 12 HIGH are all in the Go standard
+library compiled into the binary (net/http ReverseProxy, MIME-header DoS, etc.),
 flagged because the task pins the builder to `golang:1.24`; they're fixed in Go
-1.25.11 / 1.26.4, so bumping the toolchain would clear them — but the lab requires
+1.25.11 / 1.26.4, so bumping the toolchain would clear them but the lab requires
 the builder pinned to 1.24, so I kept it and documented the trade-off. The lesson:
 distroless removes the OS attack surface, but your application's own toolchain
 version is still your responsibility.
-
----
-
-## Summary
-
-| Task | Result |
-|------|--------|
-| 1 — Dockerfile ≤ 25 MB | multi-stage, distroless nonroot, static stripped binary; `docker images` = **22.7 MB**; healthy `200` |
-| 2 — Compose + volume | named volume survives `down`, dies on `down -v`; Go-probe healthcheck → `healthy` |
-| Bonus — 6 defaults | nonroot, distroless, `cap_drop ALL`, read-only+tmpfs, no-new-privileges, Trivy (0 OS CVEs) — all verified |


### PR DESCRIPTION
## Goal
Reproducible QuickNotes: a Nix flake that builds a bit-identical binary and a deterministic OCI image.

## Changes
- `flake.nix` / `flake.lock`: `buildGoModule` (static, `vendorHash = null`, `-s -w`); nixpkgs pinned to nixos-25.05
- Deterministic OCI image via `dockerTools.buildImage` (no Docker daemon, epoch mtimes, nonroot 65534)
- `.github/workflows/nix-repro.yml`: two independent runners build the image; a compare job fails unless the digests match
- `submissions/lab11.md`

## Testing
- Two independent builds -> identical store hash `sha256:1z6fc78k...` **and** identical OCI SHA-256 `c27cf6d0...`
- Contrast: `docker build --no-cache` twice -> digests differ (non-reproducible)
- Sizes: Nix image 21.4 MB vs Lab 6 22.7 MB

## Checklist
- [x] Title is a clear sentence (<= 70 chars)
- [x] Commits are signed (`git log --show-signature`)
- [x] `submissions/labN.md` updated
